### PR TITLE
Remove unnecessary function call from chipmunk.py.

### DIFF
--- a/chipmunk.py
+++ b/chipmunk.py
@@ -4,7 +4,7 @@ import sys
 import re
 
 from compiler import Compiler
-from utils import get_num_pkt_fields_and_state_vars
+
 
 def main(argv):
     """Main program."""
@@ -17,13 +17,9 @@ def main(argv):
         exit(1)
 
     program_file = str(argv[1])
-    (num_fields_in_prog, num_state_vars) = get_num_pkt_fields_and_state_vars(
-        Path(program_file).read_text())
     alu_file = str(argv[2])
     num_pipeline_stages = int(argv[3])
     num_alus_per_stage = int(argv[4])
-    num_phv_containers = num_alus_per_stage
-    assert num_fields_in_prog <= num_phv_containers
     mode = str(argv[5])
     assert mode in ["codegen", "optverify"]
     sketch_name = str(argv[6])
@@ -56,6 +52,7 @@ def main(argv):
         sys.exit(0)
     else:
         compiler.optverify()
+
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/compiler.py
+++ b/compiler.py
@@ -10,6 +10,7 @@ from chipmunk_pickle import ChipmunkPickle
 from sketch_generator import SketchGenerator
 from utils import get_num_pkt_fields_and_state_vars
 
+
 class Compiler:
     def __init__(self, program_file, alu_file, num_pipeline_stages,
                  num_alus_per_stage, sketch_name, parallel_or_serial):
@@ -23,6 +24,8 @@ class Compiler:
         (self.num_fields_in_prog,
          self.num_state_vars) = get_num_pkt_fields_and_state_vars(
              Path(program_file).read_text())
+
+        assert self.num_fields_in_prog <= num_alus_per_stage
 
         # Initialize jinja2 environment for templates
         self.jinja2_env = Environment(

--- a/tests/chipmunk_test.py
+++ b/tests/chipmunk_test.py
@@ -10,6 +10,12 @@ from chipmunk import Compiler
 class ChipmunkCodegenTest(unittest.TestCase):
     """Tests codegen method from chipmunk.Compiler."""
 
+    def setUp(self):
+        self.base_path = path.abspath(path.dirname(__file__))
+        self.data_dir = path.join(self.base_path, "data/")
+        self.alu_dir = path.join(self.base_path, "../example_alus/")
+        self.spec_dir = path.join(self.base_path, "../example_specs/")
+
     def test_codegen_with_simple_sketch_for_all_alus(self):
         base_path = path.abspath(path.dirname(__file__))
         alu_dir = path.join(base_path, "../example_alus/")
@@ -23,10 +29,21 @@ class ChipmunkCodegenTest(unittest.TestCase):
             compiler = Compiler(
                 path.join(base_path, "../example_specs/simple.sk"),
                 path.join(alu_dir, alu), 2, 2, "simple", "serial")
-            self.assertEqual(compiler.codegen()[0], 0, "Compiling simple.sk failed for " + alu)
+            self.assertEqual(compiler.codegen()[
+                             0], 0, "Compiling simple.sk failed for " + alu)
             # TODO(taegyunkim): When all tests pass, clean up intermediary files
             # or at least have an option to keep intermediary files, with
             # default deleting them.
+
+    def test_raise_assertion_for_grid_size(self):
+        spec_filename = "simple.sk"
+        alu_filename = "raw.stateful_alu"
+
+        with self.assertRaises(AssertionError):
+            Compiler(
+                path.join(self.spec_dir, spec_filename),
+                path.join(self.alu_dir, alu_filename), 1, 0, "simple_raw_1_2",
+                "serial")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`get_num_pkt_fields_and_state_vars` can simply be called from compiler instead of from chipmunk. Also adds a test for raising assertion. 