### PR TITLE
Few changes to optverify.py

### DIFF
--- a/chipmunk_pickle.py
+++ b/chipmunk_pickle.py
@@ -6,4 +6,4 @@ class ChipmunkPickle():
         self.constraints_ = constraints
         self.num_fields_in_prog_ = num_fields_in_prog
         self.num_state_groups_ = num_state_groups
-        self.num_state_slots_  = num_state_slots
+        self.num_state_slots_ = num_state_slots

--- a/example_transforms/very_simple.transform
+++ b/example_transforms/very_simple.transform
@@ -2,7 +2,6 @@ sample2_stateless_alu_0_0_mux1_ctrl     = sample1_stateless_alu_0_0_mux1_ctrl;
 sample2_stateless_alu_0_0_mux2_ctrl     = sample1_stateless_alu_0_0_mux2_ctrl;
 sample2_stateless_alu_0_0_opcode        = sample1_stateless_alu_0_0_opcode;
 sample2_stateless_alu_0_0_immediate     = sample1_stateless_alu_0_0_immediate;
-sample2_stateless_alu_0_0_mode          = sample1_stateless_alu_0_0_mode;
 sample2_stateful_alu_0_0_Mux2_0_global  = sample1_stateful_alu_0_0_Mux2_0_global;
 sample2_stateful_alu_0_0_Opt_0_global   = sample1_stateful_alu_0_0_Opt_0_global;
 sample2_stateful_alu_0_0_const_0_global = sample1_stateful_alu_0_0_const_0_global;

--- a/optverify.py
+++ b/optverify.py
@@ -32,9 +32,9 @@ else:
     num_fields_in_prog = pickle.load(open(sketch1_name + ".pickle",
                                           "rb")).num_fields_in_prog_
     num_state_groups = pickle.load(open(sketch1_name + ".pickle",
-                                      "rb")).num_state_groups_
+                                        "rb")).num_state_groups_
     num_state_slots = pickle.load(open(sketch1_name + ".pickle",
-                                      "rb")).num_state_slots_
+                                       "rb")).num_state_slots_
     opt_verify_template = env.get_template("opt_verify.j2")
     opt_verifier = opt_verify_template.render(
         sketch1_name=sketch1_name,
@@ -77,5 +77,3 @@ else:
         success_file.close()
         print("Verification succeeded. Output left in " + success_file.name)
         sys.exit(0)
-
-

--- a/optverify.py
+++ b/optverify.py
@@ -12,16 +12,7 @@ def read_file(filename):
     return Path(filename).read_text()
 
 
-def main(argv):
-    """Main routine for optimization verifier."""
-    if (len(argv) < 4):
-        print("Usage: " + argv[0] +
-              " sketch1_name sketch2_name transform_file")
-        sys.exit(1)
-
-    sketch1_name = str(argv[1])
-    sketch2_name = str(argv[2])
-    transform_file = str(argv[3])
+def optverify(sketch1_name, sketch2_name, transform_file):
     env = Environment(
         loader=FileSystemLoader('./templates'), undefined=StrictUndefined)
 
@@ -75,13 +66,27 @@ def main(argv):
         errors_file.write(output)
         errors_file.close()
         print("Verification failed. Output left in " + errors_file.name)
-        sys.exit(1)
+        return 1
     else:
         success_file = open(verifier_file + ".success", "w")
         success_file.write(output)
         success_file.close()
         print("Verification succeeded. Output left in " + success_file.name)
-        sys.exit(0)
+        return 0
+
+
+def main(argv):
+    """Main routine for optimization verifier."""
+    if (len(argv) < 4):
+        print("Usage: " + argv[0] +
+              " sketch1_name sketch2_name transform_file")
+        sys.exit(1)
+
+    sketch1_name = str(argv[1])
+    sketch2_name = str(argv[2])
+    transform_file = str(argv[3])
+
+    sys.exit(optverify(sketch1_name, sketch2_name, transform_file))
 
 
 if __name__ == "__main__":

--- a/optverify.py
+++ b/optverify.py
@@ -6,19 +6,20 @@ import sys
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 
-# Read contents of filename into a string
 def read_file(filename):
     return Path(filename).read_text()
 
 
-if (len(sys.argv) < 4):
-    print("Usage: " + sys.argv[0] +
-          " sketch1_name sketch2_name transform_file")
-    sys.exit(1)
-else:
-    sketch1_name = str(sys.argv[1])
-    sketch2_name = str(sys.argv[2])
-    transform_file = str(sys.argv[3])
+def main(argv):
+    """Main routine for optimization verifier."""
+    if (len(argv) < 4):
+        print("Usage: " + argv[0] +
+              " sketch1_name sketch2_name transform_file")
+        sys.exit(1)
+
+    sketch1_name = str(argv[1])
+    sketch2_name = str(argv[2])
+    transform_file = str(argv[3])
     env = Environment(
         loader=FileSystemLoader('./templates'), undefined=StrictUndefined)
     assert (pickle.load(open(
@@ -43,8 +44,10 @@ else:
                                          "rb")).hole_arguments_,
         hole2_arguments=pickle.load(open(sketch2_name + ".pickle",
                                          "rb")).hole_arguments_,
-        sketch1_holes=pickle.load(open(sketch1_name + ".pickle", "rb")).holes_,
-        sketch2_holes=pickle.load(open(sketch2_name + ".pickle", "rb")).holes_,
+        sketch1_holes=pickle.load(
+            open(sketch1_name + ".pickle", "rb")).holes_,
+        sketch2_holes=pickle.load(
+            open(sketch2_name + ".pickle", "rb")).holes_,
         sketch1_asserts=pickle.load(open(sketch1_name + ".pickle",
                                          "rb")).constraints_,
         sketch2_asserts=pickle.load(open(sketch2_name + ".pickle",
@@ -63,7 +66,7 @@ else:
     # Call sketch on it
     (ret_code,
      output) = subprocess.getstatusoutput("time sketch -V 12 " + verifier_file)
-    if (ret_code != 0):
+    if ret_code != 0:
         errors_file = open(verifier_file + ".errors", "w")
         errors_file.write(output)
         errors_file.close()
@@ -75,3 +78,7 @@ else:
         success_file.close()
         print("Verification succeeded. Output left in " + success_file.name)
         sys.exit(0)
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/optverify.py
+++ b/optverify.py
@@ -8,9 +8,9 @@ from jinja2 import Template, Environment, FileSystemLoader, StrictUndefined
 from chipmunk_pickle import ChipmunkPickle
 
 
-# Read contents of file_name into a string
-def file_to_str(file_name):
-    return Path(file_name).read_text()
+# Read contents of filename into a string
+def read_file(filename):
+    return Path(filename).read_text()
 
 
 if (len(sys.argv) < 4):
@@ -53,7 +53,7 @@ else:
                                          "rb")).constraints_,
         num_fields_in_prog=num_fields_in_prog,
         num_state_groups=num_state_groups,
-        transform_function=file_to_str(transform_file),
+        transform_function=read_file(transform_file),
         num_state_slots=num_state_slots)
     print("Verifier file is ",
           sketch1_name + "_" + sketch2_name + "_verifier.sk")

--- a/optverify.py
+++ b/optverify.py
@@ -1,9 +1,11 @@
-from jinja2 import Template, Environment, FileSystemLoader, StrictUndefined
 from pathlib import Path
-from chipmunk_pickle import ChipmunkPickle
-import sys
 import pickle
 import subprocess
+import sys
+
+from jinja2 import Template, Environment, FileSystemLoader, StrictUndefined
+
+from chipmunk_pickle import ChipmunkPickle
 
 
 # Read contents of file_name into a string
@@ -72,3 +74,5 @@ else:
         success_file.close()
         print("Verification succeeded. Output left in " + success_file.name)
         sys.exit(0)
+
+

--- a/optverify.py
+++ b/optverify.py
@@ -3,9 +3,7 @@ import pickle
 import subprocess
 import sys
 
-from jinja2 import Template, Environment, FileSystemLoader, StrictUndefined
-
-from chipmunk_pickle import ChipmunkPickle
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 
 # Read contents of filename into a string

--- a/sol_verify.py
+++ b/sol_verify.py
@@ -2,31 +2,38 @@
 
 import sys
 import subprocess
-def sol_verify(original_sketch_file,hole_value_file):
 
-  original_sketch_file_string    = open(str(original_sketch_file),"r").read()
-  hole_value_file_string         = open(str(hole_value_file),"r").read()
 
-  #remove the hole definition in original_sketch_file
-  original_sketch_file_string = original_sketch_file_string[original_sketch_file_string.rfind('??'):]
-  original_sketch_file_string = original_sketch_file_string[original_sketch_file_string.find(';')+1:]
+def sol_verify(original_sketch_file, hole_value_file):
 
-  #remove the redundant code in hole_value_file
-  begin_pos = hole_value_file_string.find('int')
-  end_pos = hole_value_file_string.rfind(';')
-  hole_value_file_string = hole_value_file_string[begin_pos:end_pos+1]
+    original_sketch_file_string = open(str(original_sketch_file), "r").read()
+    hole_value_file_string = open(str(hole_value_file), "r").read()
 
-  sketch_file_with_hole_value = hole_value_file_string + original_sketch_file_string
+    #remove the hole definition in original_sketch_file
+    original_sketch_file_string = original_sketch_file_string[
+        original_sketch_file_string.rfind('??'):]
+    original_sketch_file_string = original_sketch_file_string[
+        original_sketch_file_string.find(';') + 1:]
 
-  # Create file and write sketch_harness into it.
-  sketch_file = open(original_sketch_file[0:original_sketch_file.find('.')] + "_with_hole_value.sk", "w")
-  sketch_file.write(sketch_file_with_hole_value)
-  sketch_file.close()
+    #remove the redundant code in hole_value_file
+    begin_pos = hole_value_file_string.find('int')
+    end_pos = hole_value_file_string.rfind(';')
+    hole_value_file_string = hole_value_file_string[begin_pos:end_pos + 1]
 
-  # Call sketch on it
-  (ret_code, output) = subprocess.getstatusoutput("sketch --bnd-inbits=10 " + sketch_file.name)
-  if (ret_code!=0):
-    #fail print 1
-    return 1
-  else:
-    return 0
+    sketch_file_with_hole_value = hole_value_file_string + original_sketch_file_string
+
+    # Create file and write sketch_harness into it.
+    sketch_file = open(
+        original_sketch_file[0:original_sketch_file.find('.')] +
+        "_with_hole_value.sk", "w")
+    sketch_file.write(sketch_file_with_hole_value)
+    sketch_file.close()
+
+    # Call sketch on it
+    (ret_code, output) = subprocess.getstatusoutput("sketch --bnd-inbits=10 " +
+                                                    sketch_file.name)
+    if (ret_code != 0):
+        #fail print 1
+        return 1
+    else:
+        return 0

--- a/tests/chipmunk_test.py
+++ b/tests/chipmunk_test.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import unittest
 
 from chipmunk import Compiler
+from optverify import optverify
 from utils import get_hole_dicts
 
 
@@ -67,6 +68,36 @@ class ChipmunkCodegenTest(unittest.TestCase):
                            "../simple_raw_2_2_codegen.sk")).read_text())
 
         self.assertEqual(sorted(expected_holes), sorted(output_holes))
+
+
+class OptverifyTest(unittest.TestCase):
+    def setUp(self):
+        self.base_path = path.abspath(path.dirname(__file__))
+        self.alu_dir = path.join(self.base_path, "../example_alus/")
+        self.spec_dir = path.join(self.base_path, "../example_specs/")
+        self.transform_dir = path.join(self.base_path,
+                                       "../example_transforms/")
+
+    def test_simple_sketch_same_config(self):
+        spec_filename = "simple.sk"
+        alu_filename = "raw.stateful_alu"
+
+        compiler = Compiler(
+            path.join(self.spec_dir, spec_filename),
+            path.join(self.alu_dir, alu_filename), 1, 1, "sample1", "serial")
+
+        compiler.optverify()
+
+        compiler = Compiler(
+            path.join(self.spec_dir, spec_filename),
+            path.join(self.alu_dir, alu_filename), 1, 1, "sample2", "serial")
+
+        compiler.optverify()
+
+        self.assertEqual(
+            0,
+            optverify("sample1", "sample2",
+                      path.join(self.transform_dir, "very_simple.transform")))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Define a main() and add `__main__` check. This is necessary to later make opverify a separate cli command. 
2. Instead of opening pickle files multiple times and not closing all of them, just read once for each files and properly close them with `with`.
3. Changes to other files are rather cosmetic. 