### PR TITLE
Setup continuous integration using AppVeyor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Chipmunk
 
+[![Build status](https://ci.appveyor.com/api/projects/status/060fwhaq3vfvt22n/branch/master?svg=true)](https://ci.appveyor.com/project/anirudhSK/chipmunk-hhg5f/branch/master)
+
 ## Installation
 - Install [antlr](https://www.antlr.org/)
 - Install [sketch](https://people.csail.mit.edu/asolar/sketch-1.7.5.tar.gz)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,87 @@
+version: 1.0.{build}
+image: Ubuntu1604
+build_script:
+- sh: >-
+    set -e
+
+    sudo apt-get update
+
+    sudo add-apt-repository ppa:webupd8team/java -y
+
+    sudo apt-get update
+
+    sudo apt-get install -y bison python3-pip flex
+
+    sudo apt-get remove -y default-jre
+
+    sudo apt-get remove -y openjdk-10-jre openjdk-9-jre
+
+    echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
+
+    echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
+
+    sudo apt-get install -y oracle-java8-installer
+
+    export PATH="/usr/lib/jvm/java-8-oracle/bin:/usr/lib/jvm/java-8-oracle/db/bin:/usr/lib/jvm/java-8-oracle/jre/bin":$PATH
+
+    cd /usr/local/lib
+
+    sudo wget https://www.antlr.org/download/antlr-4.7.2-complete.jar
+
+    export CLASSPATH=".:/usr/local/lib/antlr-4.7.2-complete.jar:$CLASSPATH"
+
+    antlr4='java -jar /usr/local/lib/antlr-4.7.2-complete.jar'
+
+    cd ~
+
+    wget https://people.csail.mit.edu/asolar/sketch-1.7.5.tar.gz
+
+    tar xvzf sketch-1.7.5.tar.gz
+
+    cd sketch-1.7.5
+
+    cd sketch-backend
+
+    chmod +x ./configure
+
+    ./configure
+
+    make
+
+    cd ..
+
+    cd sketch-frontend
+
+    chmod +x ./sketch
+
+    ./sketch test/sk/seq/miniTest1.sk
+
+    export PATH="$PATH:`pwd`"
+
+    export SKETCH_HOME="`pwd`/runtime"
+
+    cd ~
+
+    git clone https://github.com/anirudhSK/chipmunk
+
+    cd chipmunk
+
+    sudo pip3 install -r requirements.txt
+
+    sudo pip3 install .
+
+    chipmunk example_specs/simple.sk example_alus/raw.stateful_alu 2 2 codegen sample1 serial
+
+    chipmunk example_specs/simple.sk example_alus/raw.stateful_alu 2 2 codegen sample1 parallel
+
+    chipmunk example_specs/simple.sk example_alus/raw.stateful_alu 1 1 optverify sample1 serial
+
+    chipmunk example_specs/simple.sk example_alus/raw.stateful_alu 1 1 optverify sample2 serial
+
+    optverify sample1 sample2 example_transforms/very_simple.transform
+
+    $antlr4 chipc/stateful_alu.g4 -Dlanguage=Python3 -visitor -package chipc
+
+    chipmunk_parallel example_specs/simple.sk example_alus/raw.stateful_alu 2 2 codegen
+
+    python3 -m unittest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -85,3 +85,5 @@ build_script:
     chipmunk_parallel example_specs/simple.sk example_alus/raw.stateful_alu 2 2 codegen
 
     python3 -m unittest
+
+    echo "ALL DONE"


### PR DESCRIPTION
Tried Travis as well, but that doesn't seem to work (the Travis VM doesn't boot up in the first place). Right now, the build times on AppVeyor are a bit long though (~5 minutes and 40 seconds), but it builds repeatably.

README.md now has a build status icon.
