### PR TITLE
Update readme regarding how to develop. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ __pycache__
 *Parser.py
 *Visitor.py
 *Listener.py
+*.egg-info
 
 !tests/data/*.sk

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ This way you don't have to keep installing and uninstalling whenever you make a
 change and test. However, still you have to run via `python chipc/chipmunk.py`
 instead of using the installed binary.
 
+Also consider using [venv](https://docs.python.org/3/library/venv.html),
+[virtualenv](https://virtualenv.pypa.io/en/latest/) or
+[pipenv](https://pipenv.readthedocs.io/en/latest/) to create an isolated Python
+development environment.
+
 
 ### Codegen
 

--- a/README.md
+++ b/README.md
@@ -12,29 +12,24 @@
 
 ### Develop
 
-When you run `python3 chipc/chipmunk.py ...`, Python will complain like following.
+If you have installed it as above, first uninstall and re-install via following
+command.
+
 ```shell
-Traceback (most recent call last):
-  File "chipc/chipmunk.py", line 6, in <module>
-    from chipc.compiler import Compiler
-ModuleNotFoundError: No module named 'chipc'
+pip uninstall chipc && pip install -e .
 ```
-It's because how we import all the modules in this package: we're using absolute imports.
 
-You can simply iterate like following
-1. make changes to any module
-2. pip install .
-3. run `chipmunk` or other binaries to see your change is working or not
-4. Make more changes
-5. pip uninstall chipc
-6. pip install .
+Note that there is `-e` in install command. It will install this package in
+development mode, and simply link actual chipc directory to your Python's
+site-packages directory.
 
-and many more steps like this
+1. Make changes to python code
+2. Consider implementing tests and run tests `python -m unittest`
+3. Run your desired binary like `python chipc/chipmunk.py ...`
 
-Since this process will be prone to confusion, simply do following, when developing.
-1. `pip install -e .`
-2. Make changes to any module
-3. `python3 chipc/chipmunk.py ...`
+This way you don't have to keep installing and uninstalling whenever you make a
+change and test. However, still you have to run via `python chipc/chipmunk.py`
+instead of using the installed binary.
 
 
 ### Codegen

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 - `pip3 install -r requirements.txt && pip3 install .`(from this directory)
 (Add sudo if you want to install system wide.)
 
+When devloping, to avoid repeatedly installing and uninstalling this, you can
+install as a development egg, and your change will be immediately active.
+`pip3 install -r requirements.txt && pip3 install -e .`
+
 ## How to
 
 ### Codegen

--- a/README.md
+++ b/README.md
@@ -8,11 +8,34 @@
 - `pip3 install -r requirements.txt && pip3 install .`(from this directory)
 (Add sudo if you want to install system wide.)
 
-When devloping, to avoid repeatedly installing and uninstalling this, you can
-install as a development egg, and your change will be immediately active.
-`pip3 install -r requirements.txt && pip3 install -e .`
-
 ## How to
+
+### Develop
+
+When you run `python3 chipc/chipmunk.py ...`, Python will complain like following.
+```shell
+Traceback (most recent call last):
+  File "chipc/chipmunk.py", line 6, in <module>
+    from chipc.compiler import Compiler
+ModuleNotFoundError: No module named 'chipc'
+```
+It's because how we import all the modules in this package: we're using absolute imports.
+
+You can simply iterate like following
+1. make changes to any module
+2. pip install .
+3. run `chipmunk` or other binaries to see your change is working or not
+4. Make more changes
+5. pip uninstall chipc
+6. pip install .
+
+and many more steps like this
+
+Since this process will be prone to confusion, simply do following, when developing.
+1. `pip install -e .`
+2. Make changes to any module
+3. `python3 chipc/chipmunk.py ...`
+
 
 ### Codegen
 

--- a/chipc/chipmunk.py
+++ b/chipc/chipmunk.py
@@ -61,4 +61,5 @@ def run_main():
 
 
 if __name__ == "__main__":
+    print("test")
     run_main()

--- a/chipc/chipmunk.py
+++ b/chipc/chipmunk.py
@@ -61,5 +61,4 @@ def run_main():
 
 
 if __name__ == "__main__":
-    print("test")
     run_main()


### PR DESCRIPTION
During development, if you run `python3 chipc/chipmunk.py ...`, Python will complain like following. 
```shell
Traceback (most recent call last):
  File "chipc/chipmunk.py", line 6, in <module>
    from chipc.compiler import Compiler
ModuleNotFoundError: No module named 'chipc'
```
It's because how we import all the modules in this package: we're using absolute imports. 

Do following
1. `pip install -e .`
This will simply link actual chipc directory to your Python's site-packages, and your changes will be reflected immediately without re-installing. 
2. Make changes to any module
3. `python3 chipc/chipmunk.py ...`

However, still you have to run via `python chipc/chipmunk.py...` instead of using the installed binary, like `chipmunk ...`