### PR TITLE
Fix bug for different compilation result for cex_mode & hole_elimination_mode

### DIFF
--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -18,7 +18,7 @@ def main(argv):
               "<number of stateless/stateful ALUs per stage> " +
               "<sketch_name (w/o file extension)> <parallel/serial> " +
               "<cex_mode/hole_elimination_mode>")
-        sys.exit(1)
+        return 1
 
     start_time = time.time()
     program_file = str(argv[1])
@@ -45,7 +45,7 @@ def main(argv):
         print("failed to compile with 2 bits.")
         end_time = time.time()
         print("total time in seconds: ", end_time - start_time)
-        sys.exit(1)
+        return 1
 
     # Generate the result file
     with open("/tmp/" + sketch_name + "_result.holes", "w") as result_file:
@@ -58,7 +58,7 @@ def main(argv):
         print("success")
         end_time = time.time()
         print("total time in seconds: ", end_time - start_time)
-        sys.exit(0)
+        return 0
 
     print("failed for larger size and need repeated testing by sketch")
     # start to repeated run sketch until get the final result
@@ -182,7 +182,7 @@ def main(argv):
                 print("finally succeed")
                 end_time = time.time()
                 print("total time in seconds: ", end_time - start_time)
-                exit(0)
+                return 0
             else:
                 count = count + 1
                 continue
@@ -192,7 +192,7 @@ def main(argv):
             end_time = time.time()
             print("total time in seconds: ", end_time - start_time)
             print("total while loop: ", count)
-            sys.exit(1)
+            return 1
 
 
 def run_main():

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -39,7 +39,7 @@ def main(argv):
 
     # Can swap this out for compiler.parallel_codegen() instead
     # TODO: But we need to do this in all iterations below as well.
-    (ret_code, output, _) = compiler.serial_codegen()
+    (ret_code, output, hole_names) = compiler.serial_codegen()
 
     if ret_code != 0:
         print("failed to compile with 2 bits.")
@@ -53,6 +53,7 @@ def main(argv):
     # Step2: run sol_verify.py
     ret_code = sol_verify(sketch_name + "_codegen.sk",
                           "/tmp/" + sketch_name + "_result.holes")
+    # ret_code = 0 means sol_verify success
     if ret_code == 0:
         print("success")
         end_time = time.time()
@@ -65,17 +66,13 @@ def main(argv):
     count = 0
     while 1:
         if mode == "hole_elimination_mode":
-            hole_value_file_string = Path("/tmp/" + sketch_name +
-                                          "_result.holes").read_text()
-            begin_pos = hole_value_file_string.find('int')
-            end_pos = hole_value_file_string.rfind(';')
-            hole_value_file_string = hole_value_file_string[begin_pos:end_pos +
-                                                            1]
-            #rearrange the format (int x=1; int y=2;) to (x==1 && y==2 && 1)
-            hole_value_file_string = hole_value_file_string.replace("int", "")
-            hole_value_file_string = hole_value_file_string.replace("=", "==")
-            hole_value_file_string = hole_value_file_string.replace(";", "&&")
-            hole_value_file_string = hole_value_file_string + "1"
+            # holes_to_values is in the format {'hole_name':'hole_value'} i.e{'sample1_stateless_alu_0_0_mux1_ctrl': '0'}
+            holes_to_values = get_hole_value_assignments(hole_names, output)
+            hole_value_file_string = ""
+            # hole_value_file_string has the format hole_1==1 && hole_2==2 && 1
+            for hole, value in holes_to_values.items():
+              hole_value_file_string += hole + " == " + value + " && "
+            hole_value_file_string += "1"
             #find the position of harness
             begin_pos = original_sketch_file_string.find('harness')
             begin_pos = original_sketch_file_string.find('assert', begin_pos)

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -71,7 +71,7 @@ def main(argv):
             hole_value_file_string = ""
             # hole_value_file_string has the format hole_1==1 && hole_2==2 && 1
             for hole, value in holes_to_values.items():
-              hole_value_file_string += hole + " == " + value + " && "
+                hole_value_file_string += hole + " == " + value + " && "
             hole_value_file_string += "1"
             #find the position of harness
             begin_pos = original_sketch_file_string.find('harness')

--- a/chipc/sol_verify.py
+++ b/chipc/sol_verify.py
@@ -4,8 +4,10 @@ import subprocess
 
 
 def sol_verify(original_sketch_file, hole_value_file):
-    original_sketch_file_string = open(str(original_sketch_file), "r").read()
-    hole_value_file_string = open(str(hole_value_file), "r").read()
+    with open(original_sketch_file, "r") as sketch_file_handle:
+        original_sketch_file_string = sketch_file_handle.read()
+    with open(hole_value_file, "r") as hole_value_file_handle:
+        hole_value_file_string = hole_value_file_handle.read()
 
     #remove the hole definition in original_sketch_file
     original_sketch_file_string = original_sketch_file_string[

--- a/tests/test_chipmunk.py
+++ b/tests/test_chipmunk.py
@@ -124,10 +124,16 @@ class OptverifyTest(unittest.TestCase):
                       path.join(TRANSFORM_DIR, "very_simple.transform")))
 
 class IterativeSolverTest(unittest.TestCase):
-    def test_simple_sketch_2_2_raw(self):
+    def test_simple_sketch_2_2_raw_cex_mode(self):
         self.assertEqual(
             0,
             chipc.iterative_solver.main(["iterative_solver", path.join(SPEC_DIR,"simple.sk"), path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1", "serial", "cex_mode"]),
+            )
+
+    def test_simple_sketch_2_2_raw_hole_elimination_mode(self):
+        self.assertEqual(
+            0,
+            chipc.iterative_solver.main(["iterative_solver", path.join(SPEC_DIR,"simple.sk"), path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1", "serial", "hole_elimination_mode"]),
             )
 
 if __name__ == '__main__':

--- a/tests/test_chipmunk.py
+++ b/tests/test_chipmunk.py
@@ -14,7 +14,7 @@ ALU_DIR = path.join(BASE_PATH, "../example_alus/")
 SPEC_DIR = path.join(BASE_PATH, "../example_specs/")
 TRANSFORM_DIR = path.join(BASE_PATH, "../example_transforms/")
 
-
+# TODO(Xiangyu): Add more test function for iterative_solver with hole_elimination_mode and cex_mode
 class TestChipmunkCodegen(unittest.TestCase):
     """Tests codegen method from chipmunk.Compiler."""
 

--- a/tests/test_chipmunk.py
+++ b/tests/test_chipmunk.py
@@ -125,7 +125,7 @@ class OptverifyTest(unittest.TestCase):
 
 
 class IterativeSolverTest(unittest.TestCase):
-    def test_simple_sketch_2_2_raw_cex_mode(self):
+    def test_simple_2_2_raw_cex_mode(self):
         self.assertEqual(
             0,
             iterative_solver.main([
@@ -136,7 +136,7 @@ class IterativeSolverTest(unittest.TestCase):
             ]),
         )
 
-    def test_simple_sketch_2_2_raw_hole_elimination_mode(self):
+    def test_simple_2_2_raw_hole_elimination_mode(self):
         self.assertEqual(
             0,
             iterative_solver.main([
@@ -147,6 +147,16 @@ class IterativeSolverTest(unittest.TestCase):
             ]),
         )
 
+
+    def test_sampling_revised_2_2_raw_cex_mode(self):
+        self.assertEqual(
+            1,
+            iterative_solver.main([
+                "iterative_solver",
+                path.join(SPEC_DIR,"sampling_revised.sk"),
+                path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1",
+                "serial", "cex_mode"]),
+            )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_chipmunk.py
+++ b/tests/test_chipmunk.py
@@ -7,6 +7,7 @@ import unittest
 from chipc.direct_solver import Compiler
 from chipc.optverify import optverify
 from chipc.utils import get_hole_dicts
+import chipc.iterative_solver
 
 BASE_PATH = path.abspath(path.dirname(__file__))
 DATA_DIR = path.join(BASE_PATH, "data/")
@@ -14,8 +15,7 @@ ALU_DIR = path.join(BASE_PATH, "../example_alus/")
 SPEC_DIR = path.join(BASE_PATH, "../example_specs/")
 TRANSFORM_DIR = path.join(BASE_PATH, "../example_transforms/")
 
-# TODO(Xiangyu): Add more test function for iterative_solver with hole_elimination_mode and cex_mode
-class TestChipmunkCodegen(unittest.TestCase):
+class TestDirectSolver(unittest.TestCase):
     """Tests codegen method from chipmunk.Compiler."""
 
     def test_codegen_with_simple_sketch_for_all_alus(self):
@@ -123,6 +123,12 @@ class OptverifyTest(unittest.TestCase):
             optverify("sample1", "sample2",
                       path.join(TRANSFORM_DIR, "very_simple.transform")))
 
+class IterativeSolverTest(unittest.TestCase):
+    def test_simple_sketch_2_2_raw(self):
+        self.assertEqual(
+            0,
+            chipc.iterative_solver.main(["iterative_solver", path.join(SPEC_DIR,"simple.sk"), path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1", "serial", "cex_mode"]),
+            )
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_chipmunk.py
+++ b/tests/test_chipmunk.py
@@ -4,16 +4,17 @@ from os import path, listdir, getcwd
 from pathlib import Path
 import unittest
 
-from chipc.direct_solver import Compiler
+from chipc import iterative_solver
+from chipc.compiler import Compiler
 from chipc.optverify import optverify
 from chipc.utils import get_hole_dicts
-import chipc.iterative_solver
 
 BASE_PATH = path.abspath(path.dirname(__file__))
 DATA_DIR = path.join(BASE_PATH, "data/")
 ALU_DIR = path.join(BASE_PATH, "../example_alus/")
 SPEC_DIR = path.join(BASE_PATH, "../example_specs/")
 TRANSFORM_DIR = path.join(BASE_PATH, "../example_transforms/")
+
 
 class TestDirectSolver(unittest.TestCase):
     """Tests codegen method from chipmunk.Compiler."""
@@ -27,8 +28,8 @@ class TestDirectSolver(unittest.TestCase):
             # TODO(taegyunkim): Instead of writing to the same success and
             # failure files, use different files for each ALU.
             compiler = Compiler(
-                path.join(SPEC_DIR, "simple.sk"),
-                path.join(ALU_DIR, alu), 2, 2, "simple", "serial")
+                path.join(SPEC_DIR, "simple.sk"), path.join(ALU_DIR, alu), 2,
+                2, "simple", "serial")
             self.assertEqual(compiler.serial_codegen()[0], 0,
                              "Compiling simple.sk failed for " + alu)
             # TODO(taegyunkim): When all tests pass, clean up intermediary files
@@ -61,8 +62,7 @@ class TestDirectSolver(unittest.TestCase):
             Path(path.join(DATA_DIR, "simple_raw_2_2_codegen.sk")).read_text())
 
         output_holes = get_hole_dicts(
-            Path(path.join(getcwd(),
-                           "simple_raw_2_2_codegen.sk")).read_text())
+            Path(path.join(getcwd(), "simple_raw_2_2_codegen.sk")).read_text())
 
         self.assertEqual(sorted(expected_holes), sorted(output_holes))
 
@@ -107,14 +107,14 @@ class OptverifyTest(unittest.TestCase):
         alu_filename = "raw.stateful_alu"
 
         compiler = Compiler(
-            path.join(SPEC_DIR, spec_filename),
-            path.join(ALU_DIR, alu_filename), 1, 1, "sample1", "serial")
+            path.join(SPEC_DIR, spec_filename), path.join(
+                ALU_DIR, alu_filename), 1, 1, "sample1", "serial")
 
         compiler.optverify()
 
         compiler = Compiler(
-            path.join(SPEC_DIR, spec_filename),
-            path.join(ALU_DIR, alu_filename), 1, 1, "sample2", "serial")
+            path.join(SPEC_DIR, spec_filename), path.join(
+                ALU_DIR, alu_filename), 1, 1, "sample2", "serial")
 
         compiler.optverify()
 
@@ -123,18 +123,30 @@ class OptverifyTest(unittest.TestCase):
             optverify("sample1", "sample2",
                       path.join(TRANSFORM_DIR, "very_simple.transform")))
 
+
 class IterativeSolverTest(unittest.TestCase):
     def test_simple_sketch_2_2_raw_cex_mode(self):
         self.assertEqual(
             0,
-            chipc.iterative_solver.main(["iterative_solver", path.join(SPEC_DIR,"simple.sk"), path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1", "serial", "cex_mode"]),
-            )
+            iterative_solver.main([
+                "iterative_solver",
+                path.join(SPEC_DIR, "simple.sk"),
+                path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1",
+                "serial", "cex_mode"
+            ]),
+        )
 
     def test_simple_sketch_2_2_raw_hole_elimination_mode(self):
         self.assertEqual(
             0,
-            chipc.iterative_solver.main(["iterative_solver", path.join(SPEC_DIR,"simple.sk"), path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1", "serial", "hole_elimination_mode"]),
-            )
+            iterative_solver.main([
+                "iterative_solver",
+                path.join(SPEC_DIR, "simple.sk"),
+                path.join(ALU_DIR, "raw.stateful_alu"), 2, 2, "sample1",
+                "serial", "hole_elimination_mode"
+            ]),
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In master branch when we run following command, it succeeds. 
iterative_solver example_specs/sampling_revised.sk example_alus/raw.stateful_alu 2 2 sample1 serial cex_mode

However, hole_elimination_mode with the same parameters fails. 
iterative_solver example_specs/sampling_revised.sk example_alus/raw.stateful_alu 2 2 sample1 serial hole_elimination_mode

The compilation results are different and this has been fixed in this branch