### PR TITLE
Just use openjdk-8-jdk

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,8 @@ init:
 
     sudo apt-get install -y bison python3-pip flex
 
+    java -verion
+
     cd /usr/local/lib
 
     sudo wget https://www.antlr.org/download/antlr-4.7.2-complete.jar

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,23 +8,7 @@ init:
 
     sudo apt-get update
 
-    sudo add-apt-repository ppa:webupd8team/java -y
-
-    sudo apt-get update
-
-    sudo apt-get install -y bison python3-pip flex
-
-    sudo apt-get remove -y default-jre
-
-    sudo apt-get remove -y openjdk-10-jre openjdk-9-jre
-
-    echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections
-
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections
-
-    sudo apt-get install -y oracle-java8-installer
-
-    export PATH="/usr/lib/jvm/java-8-oracle/bin:/usr/lib/jvm/java-8-oracle/db/bin:/usr/lib/jvm/java-8-oracle/jre/bin":$PATH
+    sudo apt-get install -y bison python3-pip flex openjdk-8-jdk
 
     cd /usr/local/lib
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,13 @@ init:
 
     sudo apt-get update
 
-    sudo apt-get install -y bison python3-pip flex openjdk-8-jdk
+    sudo apt-get install -y bison python3-pip flex
+
+    sudo apt-get remove -y default-jre
+
+    sudo apt-get remove -y openjdk-10-jre openjdk-9-jre
+
+    sudo apt-get install openjdk-8-jre
 
     cd /usr/local/lib
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,11 +1,9 @@
 version: 1.0.{build}
-image: Ubuntu
+image: Ubuntu1604
 stack: jdk 8
 install:
 - sh: >-
     old_dir=`pwd`
-
-    java -version
 
     set -e
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,8 @@
 version: 1.0.{build}
+environment:
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
+      JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
 image: Ubuntu1604
 stack: jdk 8
 init:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ init:
 
     sudo apt-get install -y bison python3-pip flex
 
-    java -verion
+    java -version
 
     cd /usr/local/lib
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 version: 1.0.{build}
-environment:
-  matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu1604
-      JAVA_HOME: "/usr/lib/jvm/java-8-openjdk-amd64"
-image: Ubuntu1604
+image: Ubuntu
 stack: jdk 8
 init:
 - sh: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,13 +5,13 @@ init:
 - sh: >-
     old_dir=`pwd`
 
+    java -version
+
     set -e
 
     sudo apt-get update
 
     sudo apt-get install -y bison python3-pip flex
-
-    java -version
 
     cd /usr/local/lib
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ init:
 
     sudo apt-get remove -y openjdk-10-jre openjdk-9-jre
 
-    sudo apt-get install openjdk-8-jre
+    sudo apt-get install -y openjdk-8-jre
 
     cd /usr/local/lib
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 image: Ubuntu
 stack: jdk 8
-init:
+install:
 - sh: >-
     old_dir=`pwd`
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,6 @@ init:
 
     sudo apt-get install -y bison python3-pip flex
 
-    sudo apt-get remove -y default-jre
-
-    sudo apt-get remove -y openjdk-10-jre openjdk-9-jre
-
-    sudo apt-get install -y openjdk-8-jre
-
     cd /usr/local/lib
 
     sudo wget https://www.antlr.org/download/antlr-4.7.2-complete.jar

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,6 @@
 version: 1.0.{build}
 image: Ubuntu1604
+stack: jdk 8
 init:
 - sh: >-
     old_dir=`pwd`


### PR DESCRIPTION
Following is the order appveyor runs command. 

stack runs after init, and we're actually installing deps, so moved all the things in init to install. 

init scripts
Update /etc/hosts file
Clone repository
Restore build cache
Configure stack
install scripts
Start services
Patch version in .csproj and AssemblyInfo.cs files
“build” phase
“test” phase
“package” phase
“deploy” phase
on_success scripts
on_failure scripts (if the build has failed)
on_finish scripts
