### PR TITLE
Add bit_range as a parameter for generate_smt2_formula

### DIFF
--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -227,8 +227,9 @@ class Compiler:
         sketch_filename = sol_verify_basename + '.sk'
         smt2_filename = sol_verify_basename + '.smt2'
         Path(sketch_filename).write_text(sol_verify_code)
-
-        sketch_utils.generate_smt2_formula(sketch_filename, smt2_filename)
+        # TODO: set the sol_verify bit to be 10 now
+        # Later will pass this value as a parameter
+        sketch_utils.generate_smt2_formula(sketch_filename, smt2_filename, 10)
 
         if z3_utils.simple_check(smt2_filename):
             return 0
@@ -250,6 +251,7 @@ class Compiler:
 
         # We only need following sketch call's side-effect, corresponding .smt2
         # file for the sketch.
-        sketch_utils.generate_smt2_formula(sketch_filename, smt2_filename)
+        sketch_utils.generate_smt2_formula(
+            sketch_filename, smt2_filename, bits_val)
 
         return z3_utils.generate_counter_examples(smt2_filename)

--- a/chipc/sketch_utils.py
+++ b/chipc/sketch_utils.py
@@ -30,11 +30,12 @@ def synthesize(sketch_file_name, bnd_inbits, slv_seed, slv_parallel=False):
     return (return_code, output)
 
 
-def generate_smt2_formula(sketch_file_name, smt_file_name):
+def generate_smt2_formula(sketch_file_name, smt_file_name, bit_range):
     check_syntax(sketch_file_name)
     (return_code, output) = subprocess.getstatusoutput('sketch ' +
                                                        sketch_file_name +
-                                                       ' --bnd-inbits=10'
+                                                       ' --bnd-inbits=' +
+                                                       str(bit_range) +
                                                        ' --slv-timeout=0.001' +
                                                        ' --beopt:writeSMT ' +
                                                        smt_file_name)


### PR DESCRIPTION
Previously, our way of generating counterexample has a bug.

Actually, we should pass our input range to sketch before generating the .smt2 file. To be specific, we add --bnd-inbits="current bit_range" rather than set "--bnd-inbits=10"