### PR TITLE
Use explicit regex patterns for pkt variables and state variables.

### DIFF
--- a/chipc/z3_utils.py
+++ b/chipc/z3_utils.py
@@ -62,13 +62,16 @@ def generate_counter_examples(smt2_filename):
 
     model = z3_slv.model()
     for var in model.decls():
-        # The variable names used by sketch have trailing _\d+_\d+_\d+ pattern,
-        # need to remove them to get original variable names.
-        var_name = re.sub(r'_\d+_\d+_\d+$', '', var.name(), count=1)
         value = model.get_interp(var).as_long()
-        if var_name.startswith('pkt_'):
+        match_object = re.match(r'pkt_\d+', var.name())
+        if match_object:
+            var_name = match_object.group(0)
             pkt_fields[var_name] = value
-        elif var_name.startswith('state_group_'):
+            continue
+
+        match_object = re.match(r'state_group_\d+_state_\d+', var.name())
+        if match_object:
+            var_name = match_object.group(0)
             state_vars[var_name] = value
 
     return (pkt_fields, state_vars)

--- a/tests/test_z3_utils.py
+++ b/tests/test_z3_utils.py
@@ -71,6 +71,14 @@ class GenerateCounterExampleTest(unittest.TestCase):
             self.assertDictEqual(pkt_fields, {})
             self.assertDictEqual(state_vars, {})
 
+    def test_state_group_with_alphabets(self):
+        x = z3.Int('state_group_1_state_0_b_b_0')
+        simple_formula = z3.ForAll([x], z3.And(x > 3, x < 2))
+        with patch('z3.parse_smt2_file', return_value=[simple_formula]):
+            _, state_vars = z3_utils.generate_counter_examples(
+                'foobar')
+            self.assertDictEqual(state_vars, {'state_group_1_state_0': 0})
+
 
 class SimpleCheckTest(unittest.TestCase):
     def test_success(self):


### PR DESCRIPTION
This should fix #117 