### PR TITLE
Do not add default values as counterexamples when z3 was not able to find one. 

### DIFF
--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -146,25 +146,17 @@ def main(argv):
     additional_testcases = ''
     sol_verify_bit = args.max_input_bit
     while 1:
-        if args.hole_elimination:
-            (synthesis_ret_code, _, hole_assignments) = \
-                compiler.parallel_codegen(
-                    additional_constraints=hole_elimination_assert) \
-                if args.parallel else \
-                compiler.serial_codegen(
-                iter_cnt=count,
-                additional_constraints=hole_elimination_assert)
-
-        else:
-            (synthesis_ret_code, _, hole_assignments) = \
-                compiler.parallel_codegen(
-                    additional_testcases=additional_testcases) \
-                if args.parallel else \
-                compiler.serial_codegen(
-                iter_cnt=count,
-                additional_testcases=additional_testcases)
-
         print('Iteration #' + str(count))
+        (synthesis_ret_code, _, hole_assignments) = \
+            compiler.parallel_codegen(
+                additional_constraints=hole_elimination_assert,
+                additional_testcases=additional_testcases) \
+            if args.parallel else \
+            compiler.serial_codegen(
+            iter_cnt=count,
+            additional_constraints=hole_elimination_assert,
+            additional_testcases=additional_testcases)
+
         if synthesis_ret_code == 0:
             print('Synthesis succeeded with 2 bits, proceeding to '
                   'verification.')

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -52,8 +52,7 @@ def generate_additional_testcases(hole_assignments, compiler,
         (cex_pkt_fields, cex_state_vars) = compiler.counter_example_generator(
             bits, hole_assignments, iter_cnt=count)
 
-        # This means, z3 was not able to find counterexamples for this specific
-        # input range.
+        # z3 was not able to find counterexamples for this input range.
         if len(cex_pkt_fields) == 0 and len(cex_state_vars) == 0:
             continue
 

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -52,6 +52,11 @@ def generate_additional_testcases(hole_assignments, compiler,
         (cex_pkt_fields, cex_state_vars) = compiler.counter_example_generator(
             bits, hole_assignments, iter_cnt=count)
 
+        # This means, z3 was not able to find counterexamples for this specific
+        # input range.
+        if len(cex_pkt_fields) == 0 and len(cex_state_vars) == 0:
+            continue
+
         pkt_fields, state_vars = set_default_values(
             cex_pkt_fields, cex_state_vars, num_fields_in_prog,
             state_group_info)

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -110,14 +110,13 @@ def main(argv):
         help='Whether sketch process internally uses parallelism')
     parser.add_argument(
         '--hole-elimination',
-        action='store_const',
-        const='hole_elimination_mode',
-        default='cex_mode',
-        help='Whether to iterate by eliminating holes or using counterexamples'
+        action='store_true',
+        help='If set, use hole elimination mode instead of counterexample '
+        'generation mode.'
     )
 
     args = parser.parse_args(argv[1:])
-    # Use program_content to store the program file text rather than use it
+    # Use program_content to store the program file text rather than using it
     # twice
     program_content = Path(args.program_file).read_text()
     num_fields_in_prog = get_num_pkt_fields(program_content)
@@ -147,7 +146,7 @@ def main(argv):
     additional_testcases = ''
     sol_verify_bit = args.max_input_bit
     while 1:
-        if args.hole_elimination == 'hole_elimination_mode':
+        if args.hole_elimination:
             (synthesis_ret_code, _, hole_assignments) = \
                 compiler.parallel_codegen(
                     additional_constraints=hole_elimination_assert) \
@@ -157,7 +156,6 @@ def main(argv):
                 additional_constraints=hole_elimination_assert)
 
         else:
-            assert (args.hole_elimination == 'cex_mode')
             (synthesis_ret_code, _, hole_assignments) = \
                 compiler.parallel_codegen(
                     additional_testcases=additional_testcases) \
@@ -177,12 +175,11 @@ def main(argv):
                 return 0
             else:
                 print('Verification failed. Trying again.')
-                if args.hole_elimination == 'hole_elimination_mode':
+                if args.hole_elimination:
                     hole_elimination_assert += \
                         generate_hole_elimination_assert(
                             hole_assignments)
                 else:
-                    assert (args.hole_elimination == 'cex_mode')
                     additional_testcases += generate_additional_testcases(
                         hole_assignments, compiler, num_fields_in_prog,
                         state_group_info, count, sol_verify_bit)


### PR DESCRIPTION
Previously, 
```
$> python tests/test_iterative_solver.py \
    IterativeSolverTest.test_sampling_revised_2_2_raw_cex_mode 
Total number of hole bits is 56
Sketch file is  sampling_revised_raw_stateless_alu_2_2_codegen_iteration_1.sk
Iteration #1
Synthesis succeeded with 2 bits, proceeding to verification.
Verification failed. Trying again.
Generating counterexamples of 2 bits.
Failed to generate counterexamples, z3 returned unsat
Setting value 0 for pkt_0
Setting value 0 for state_group_0_state_0
...
```

If z3 returned unsat for finding counterexamples, the formula (or sketch) is satisfiable in the given input bit range. No need to add default values.  