### PR TITLE
Wrap hole elimination asserts with additional parentheses. 

### DIFF
--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -19,9 +19,12 @@ def generate_hole_elimination_assert(hole_assignments):
 
     # The ! is to ensure a hole combination isn't present.
     hole_elimination_string = '!('
-    for hole, value in sorted(hole_assignments.items(), key=lambda x: x[0]):
-        hole_elimination_string += '(' + hole + ' == ' + value + ') && '
-    hole_elimination_string += '1)'
+    for idx, (hole, value) in enumerate(
+            sorted(hole_assignments.items(), key=lambda x: x[0])):
+        hole_elimination_string += '(' + hole + ' == ' + value + ')'
+        if idx != len(hole_assignments) - 1:
+            hole_elimination_string += ' && '
+    hole_elimination_string += ')'
     return [hole_elimination_string]
 
 

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -8,10 +8,15 @@ from chipc.utils import get_num_pkt_fields
 from chipc.utils import get_state_group_info
 
 
-# Create hole_elimination_assert from hole_assignments
-# hole_assignments is in the format {'hole_name':'hole_value'},
-# i.e., {'sample1_stateless_alu_0_0_mux1_ctrl': '0'}
 def generate_hole_elimination_assert(hole_assignments):
+    """Given hole value assignments, {'n_0: 'v_0', 'n_1': 'v_1', ... }, which
+    failed to verify for larger input bit ranges, generates a single element
+    string list representing the negation of holes all equal to the values.
+    This is then passed to sketch file to avoid this specific combination of
+    hole value assignments."""
+    if len(hole_assignments) == 0:
+        return []
+
     # The ! is to ensure a hole combination isn't present.
     hole_elimination_string = '!('
     for hole, value in sorted(hole_assignments.items(), key=lambda x: x[0]):

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -13,10 +13,10 @@ from chipc.utils import get_state_group_info
 # i.e., {'sample1_stateless_alu_0_0_mux1_ctrl': '0'}
 def generate_hole_elimination_assert(hole_assignments):
     # The ! is to ensure a hole combination isn't present.
-    hole_elimination_string = '!'
-    for hole, value in hole_assignments.items():
+    hole_elimination_string = '!('
+    for hole, value in sorted(hole_assignments.items(), key=lambda x: x[0]):
         hole_elimination_string += '(' + hole + ' == ' + value + ') && '
-    hole_elimination_string += '1'
+    hole_elimination_string += '1)'
     return [hole_elimination_string]
 
 

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -19,6 +19,8 @@ def generate_hole_elimination_assert(hole_assignments):
 
     # The ! is to ensure a hole combination isn't present.
     hole_elimination_string = '!('
+    # To make it easier to test, sort the hole value assignments using the hole
+    # names.
     for idx, (hole, value) in enumerate(
             sorted(hole_assignments.items(), key=lambda x: x[0])):
         hole_elimination_string += '(' + hole + ' == ' + value + ')'

--- a/tests/test_iterative_solver.py
+++ b/tests/test_iterative_solver.py
@@ -12,10 +12,10 @@ SPEC_DIR = path.join(BASE_PATH, '../example_specs/')
 
 class GenerateHoleEliminationTest(unittest.TestCase):
     def test_success(self):
-        hole_assignments = {'a': '1', 'b': '2'}
+        hole_assignments = {'c': '3', 'a': '1', 'b': '2'}
         self.assertListEqual(
             generate_hole_elimination_assert(hole_assignments),
-            ['!((a == 1) && (b == 2))']
+            ['!((a == 1) && (b == 2) && (c == 3))']
         )
 
     def test_handle_empty_assignments(self):

--- a/tests/test_iterative_solver.py
+++ b/tests/test_iterative_solver.py
@@ -2,11 +2,21 @@ import unittest
 from os import path
 
 from chipc import iterative_solver
+from chipc.iterative_solver import generate_hole_elimination_assert
 
 BASE_PATH = path.abspath(path.dirname(__file__))
 STATEFUL_ALU_DIR = path.join(BASE_PATH, '../example_alus/')
 STATELESS_ALU_DIR = path.join(BASE_PATH, '../chipc/templates/')
 SPEC_DIR = path.join(BASE_PATH, '../example_specs/')
+
+
+class GenerateHoleEliminationTest(unittest.TestCase):
+    def test_success(self):
+        hole_assignments = {'a': '1', 'b': '2'}
+        self.assertListEqual(
+            generate_hole_elimination_assert(hole_assignments),
+            ['!((a == 1) && (b == 2) && 1)']
+        )
 
 
 class IterativeSolverTest(unittest.TestCase):

--- a/tests/test_iterative_solver.py
+++ b/tests/test_iterative_solver.py
@@ -18,6 +18,11 @@ class GenerateHoleEliminationTest(unittest.TestCase):
             ['!((a == 1) && (b == 2) && 1)']
         )
 
+    def test_handle_empty_assignments(self):
+        self.assertListEqual(
+            generate_hole_elimination_assert({}), []
+        )
+
 
 class IterativeSolverTest(unittest.TestCase):
     def test_sampling_2_1_if_else_raw_cex_mode(self):

--- a/tests/test_iterative_solver.py
+++ b/tests/test_iterative_solver.py
@@ -15,7 +15,7 @@ class GenerateHoleEliminationTest(unittest.TestCase):
         hole_assignments = {'a': '1', 'b': '2'}
         self.assertListEqual(
             generate_hole_elimination_assert(hole_assignments),
-            ['!((a == 1) && (b == 2) && 1)']
+            ['!((a == 1) && (b == 2))']
         )
 
     def test_handle_empty_assignments(self):


### PR DESCRIPTION
It was returning `!(A == 1) && (B == 2)` instead of `!((A == 1) && (B == 2))`