### PR TITLE
Revamp iterative solver verification and counterexample generation. 

### DIFF
--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -242,7 +242,7 @@ class Compiler:
             program_file=self.program_file,
             mode=Mode.CEXGEN,
             hole_assignments=hole_assignments,
-            input_offset=2**bits_val)
+            input_offset=0)
 
         cex_basename = self.sketch_name + '_cexgen_iteration_' + \
             str(iter_cnt) + '_bits_' + str(bits_val)

--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -211,47 +211,36 @@ class Compiler:
         print('Total number of hole bits is',
               self.sketch_generator.total_hole_bits_)
 
-    def sol_verify(self, hole_assignments, sol_verify_bit, iter_cnt=1):
-        """Verify hole value assignments with z3"""
-        # Check that all holes are filled.
+    def verify(self, hole_assignments, input_bits, iter_cnt=1):
+        """Verify hole value assignments for the sketch with a specific input
+        bit lengths with z3.
+
+        Returns:
+            A tuple of two dicts from string to ints, where the first one
+            represents counterexamples for packet variables and the second for
+            state group variables.
+            If the hole value assignments work for the input_bits, returns
+            a tuple of two empty dicts.
+        """
+        # Check all holes have values.
         for hole in self.sketch_generator.hole_names_:
-            assert (hole in hole_assignments)
+            assert hole in hole_assignments
 
-        # Generate and run sketch that verifies these holes on a large input
-        # range (num_input_bits)
-        sol_verify_code = self.sketch_generator.generate_sketch(
-            program_file=self.program_file,
-            mode=Mode.SOL_VERIFY,
-            hole_assignments=hole_assignments)
-
-        sol_verify_basename = self.sketch_name + \
-            '_sol_verify_iteration_' + str(iter_cnt)
-        sketch_filename = sol_verify_basename + '.sk'
-        smt2_filename = sol_verify_basename + '.smt2'
-        Path(sketch_filename).write_text(sol_verify_code)
-        sketch_utils.generate_smt2_formula(
-            sketch_filename, smt2_filename, sol_verify_bit)
-
-        if z3_utils.simple_check(smt2_filename):
-            return 0
-        return -1
-
-    def counter_example_generator(self, bits_val,
-                                  hole_assignments, iter_cnt=1):
-        cex_code = self.sketch_generator.generate_sketch(
+        # Generate and run sketch that verifies these holes on the specific
+        # input bit length.
+        sketch_to_verify = self.sketch_generator.generate_sketch(
             program_file=self.program_file,
             mode=Mode.CEXGEN,
-            hole_assignments=hole_assignments)
+            hole_assignments=hole_assignments
+        )
 
-        cex_basename = self.sketch_name + '_cexgen_iteration_' + \
-            str(iter_cnt) + '_bits_' + str(bits_val)
-        sketch_filename = cex_basename + '.sk'
-        smt2_filename = cex_basename + '.smt2'
-        Path(sketch_filename).write_text(cex_code)
+        file_basename = self.sketch_name + '_verify_iter_' + str(iter_cnt)
+        sketch_filename = file_basename + '.sk'
+        smt2_filename = file_basename + '.smt2'
+        Path(sketch_filename).write_text(sketch_to_verify)
 
-        # We only need following sketch call's side-effect, corresponding .smt2
-        # file for the sketch.
         sketch_utils.generate_smt2_formula(
-            sketch_filename, smt2_filename, bits_val)
+            sketch_filename, smt2_filename, input_bits
+        )
 
         return z3_utils.generate_counter_examples(smt2_filename)

--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -230,7 +230,7 @@ class Compiler:
         # input bit length.
         sketch_to_verify = self.sketch_generator.generate_sketch(
             program_file=self.program_file,
-            mode=Mode.CEXGEN,
+            mode=Mode.VERIFY,
             hole_assignments=hole_assignments
         )
 

--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -241,8 +241,7 @@ class Compiler:
         cex_code = self.sketch_generator.generate_sketch(
             program_file=self.program_file,
             mode=Mode.CEXGEN,
-            hole_assignments=hole_assignments,
-            input_offset=0)
+            hole_assignments=hole_assignments)
 
         cex_basename = self.sketch_name + '_cexgen_iteration_' + \
             str(iter_cnt) + '_bits_' + str(bits_val)

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -57,10 +57,6 @@ def generate_counterexample_asserts(pkt_fields, state_vars, num_fields_in_prog,
     counterexample_defs = ''
     counterexample_asserts = ''
 
-    pkt_fields, state_vars = set_default_values(
-        pkt_fields, state_vars, num_fields_in_prog, state_group_info
-    )
-
     counterexample_defs += '|StateAndPacket| x_' + str(
         count) + ' = |StateAndPacket|(\n'
     for field_name, value in pkt_fields.items():

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -116,8 +116,8 @@ def main(argv):
     parser.add_argument(
         '--hole-elimination',
         action='store_true',
-        help='If set, use hole elimination mode instead of counterexample '
-        'generation mode.'
+        help='If set, add addtional assert statements to sketch, so that we \
+              would not see the same combination of hole value assignments.'
     )
 
     args = parser.parse_args(argv[1:])

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -68,6 +68,8 @@ def generate_additional_testcases(hole_assignments, compiler,
         if len(cex_pkt_fields) == 0 and len(cex_state_vars) == 0:
             continue
 
+        print(bits, cex_pkt_fields, cex_state_vars)
+
         pkt_fields, state_vars = set_default_values(
             cex_pkt_fields, cex_state_vars, num_fields_in_prog,
             state_group_info)

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -52,46 +52,33 @@ def set_default_values(pkt_fields, state_vars, num_fields_in_prog,
     return (pkt_fields, state_vars)
 
 
-def generate_additional_testcases(hole_assignments, compiler,
-                                  num_fields_in_prog, state_group_info, count,
-                                  sol_verify_bit):
-    """Creates multiple counterexamples from 2 bits
-    to sol_verify_bit input ranges."""
-    counter_example_definition = ''
-    counter_example_assert = ''
-    for bits in range(2, sol_verify_bit):
-        print('Generating counterexamples of', str(bits), 'bits.')
-        (cex_pkt_fields, cex_state_vars) = compiler.counter_example_generator(
-            bits, hole_assignments, iter_cnt=count)
+def generate_counterexample_asserts(pkt_fields, state_vars, num_fields_in_prog,
+                                    state_group_info, count):
+    counterexample_defs = ''
+    counterexample_asserts = ''
 
-        # z3 was not able to find counterexamples for this input range.
-        if len(cex_pkt_fields) == 0 and len(cex_state_vars) == 0:
-            continue
+    pkt_fields, state_vars = set_default_values(
+        pkt_fields, state_vars, num_fields_in_prog, state_group_info
+    )
 
-        print(bits, cex_pkt_fields, cex_state_vars)
+    counterexample_defs += '|StateAndPacket| x_' + str(
+        count) + ' = |StateAndPacket|(\n'
+    for field_name, value in pkt_fields.items():
+        counterexample_defs += field_name + ' = ' + str(
+            value) + ',\n'
 
-        pkt_fields, state_vars = set_default_values(
-            cex_pkt_fields, cex_state_vars, num_fields_in_prog,
-            state_group_info)
+    for i, (state_var_name, value) in enumerate(state_vars.items()):
+        counterexample_defs += state_var_name + ' = ' + str(
+            value)
+        if i < len(state_vars) - 1:
+            counterexample_defs += ',\n'
+        else:
+            counterexample_defs += ');\n'
 
-        counter_example_definition += '|StateAndPacket| x_' + str(
-            count) + '_' + str(bits) + ' = |StateAndPacket|(\n'
-        for field_name, value in pkt_fields.items():
-            counter_example_definition += field_name + ' = ' + str(
-                value + 2**bits) + ',\n'
-
-        for i, (state_var_name, value) in enumerate(state_vars.items()):
-            counter_example_definition += state_var_name + ' = ' + str(
-                value + 2**bits)
-            if i < len(state_vars) - 1:
-                counter_example_definition += ',\n'
-            else:
-                counter_example_definition += ');\n'
-
-        counter_example_assert += 'assert (pipeline(' + 'x_' + str(
-            count) + '_' + str(bits) + ')' + ' == ' + 'program(' + 'x_' + str(
-                count) + '_' + str(bits) + '));\n'
-    return counter_example_definition + counter_example_assert
+    counterexample_asserts += 'assert (pipeline(' + 'x_' + str(
+        count) + ')' + ' == ' + 'program(' + 'x_' + str(
+            count) + '));\n'
+    return counterexample_defs + counterexample_asserts
 
 
 def main(argv):
@@ -175,30 +162,36 @@ def main(argv):
             additional_constraints=hole_elimination_assert,
             additional_testcases=additional_testcases)
 
-        if synthesis_ret_code == 0:
-            print('Synthesis succeeded with 2 bits, proceeding to '
-                  'verification.')
-            verification_ret_code = compiler.sol_verify(
-                hole_assignments, sol_verify_bit, iter_cnt=count)
-            if verification_ret_code == 0:
-                compilation_success(sketch_name, hole_assignments, output)
-                return 0
-            else:
-                print('Verification failed. Trying again.')
-                if args.hole_elimination:
-                    hole_elimination_assert += \
-                        generate_hole_elimination_assert(
-                            hole_assignments)
-                else:
-                    additional_testcases += generate_additional_testcases(
-                        hole_assignments, compiler, num_fields_in_prog,
-                        state_group_info, count, sol_verify_bit)
-                count = count + 1
-                continue
-        else:
-            # Failed synthesis at 2 bits.
+        if synthesis_ret_code != 0:
             compilation_failure(sketch_name, output)
             return 1
+
+        print('Synthesis succeeded with 2 bits, proceeding to verification.')
+        pkt_fields, state_vars = compiler.verify(
+            hole_assignments, sol_verify_bit, iter_cnt=count
+        )
+
+        if len(pkt_fields) == 0 and len(state_vars) == 0:
+            compilation_success(sketch_name, hole_assignments, output)
+            return 0
+
+        print('Verification failed, use returned counterexamples', pkt_fields,
+              state_vars)
+
+        pkt_fields, state_vars = set_default_values(
+            pkt_fields, state_vars, num_fields_in_prog, state_group_info
+        )
+
+        additional_testcases += generate_counterexample_asserts(
+            pkt_fields, state_vars, num_fields_in_prog, state_group_info, count
+        )
+
+        if args.hole_elimination:
+            hole_elimination_assert += generate_hole_elimination_assert(
+                hole_assignments
+            )
+
+        count += 1
 
 
 def run_main():

--- a/chipc/mode.py
+++ b/chipc/mode.py
@@ -3,7 +3,7 @@ from enum import Enum
 
 class Mode(Enum):
     OPTVERIFY = 1
-    SOL_VERIFY = 2
+    SOL_VERIFY = 2  # Deprecated, no longer in use.
     CODEGEN = 3
     CEXGEN = 4
 

--- a/chipc/mode.py
+++ b/chipc/mode.py
@@ -5,7 +5,7 @@ class Mode(Enum):
     OPTVERIFY = 1
     SOL_VERIFY = 2  # Deprecated, no longer in use.
     CODEGEN = 3
-    CEXGEN = 4
+    VERIFY = 4
 
     def is_OPTVERIFY(self):
         return self.name == 'OPTVERIFY'
@@ -16,5 +16,5 @@ class Mode(Enum):
     def is_CODEGEN(self):
         return self.name == 'CODEGEN'
 
-    def is_CEXGEN(self):
-        return self.name == 'CEXGEN'
+    def is_VERIFY(self):
+        return self.name == 'VERIFY'

--- a/chipc/sketch_generator.py
+++ b/chipc/sketch_generator.py
@@ -230,8 +230,7 @@ class SketchGenerator:
         return ret
 
     def generate_sketch(self, program_file, mode, additional_constraints=[],
-                        hole_assignments=dict(), additional_testcases='',
-                        input_offset=0):
+                        hole_assignments=dict(), additional_testcases=''):
         self.reset_holes_and_asserts()
         if mode == Mode.CODEGEN or mode == Mode.SOL_VERIFY or \
                 mode == Mode.CEXGEN:
@@ -278,5 +277,4 @@ class SketchGenerator:
             hole_assignments='\n'.join(
                 ['int ' + str(hole) + ' = ' + str(value) + ';'
                     for hole, value in hole_assignments.items()]),
-            additional_testcases=additional_testcases,
-            input_offset=input_offset)
+            additional_testcases=additional_testcases)

--- a/chipc/sketch_generator.py
+++ b/chipc/sketch_generator.py
@@ -233,7 +233,7 @@ class SketchGenerator:
                         hole_assignments=dict(), additional_testcases=''):
         self.reset_holes_and_asserts()
         if mode == Mode.CODEGEN or mode == Mode.SOL_VERIFY or \
-                mode == Mode.CEXGEN:
+                mode == Mode.VERIFY:
             # TODO: Need better name for j2 file.
             template = self.jinja2_env_.get_template('code_generator.j2')
         else:

--- a/chipc/templates/code_generator.j2
+++ b/chipc/templates/code_generator.j2
@@ -6,7 +6,7 @@
 
 {% if mode.is_CODEGEN() %}
 {{ hole_definitions }}
-{% elif mode.is_SOL_VERIFY() or mode.is_CEXGEN() %}
+{% elif mode.is_SOL_VERIFY() or mode.is_VERIFY() %}
 {{ hole_assignments }}
 {% endif %}
 

--- a/chipc/templates/router_data_path_sketch.j2
+++ b/chipc/templates/router_data_path_sketch.j2
@@ -165,14 +165,14 @@
     {% endfor %}) {
 
     |StateAndPacket| x = |StateAndPacket|({% for field_number in range(num_fields_in_prog) %}
-      pkt_{{field_number}} = pkt_{{field_number}} + {{input_offset}},
+      pkt_{{field_number}} = pkt_{{field_number}},
     {% endfor %}
     {% for state_group_number in range(num_state_groups) %}
       {% for slot_number in range(num_state_slots) %}
         {% if (state_group_number == num_state_groups - 1) and (slot_number == num_state_slots - 1) %}
-          state_group_{{state_group_number}}_state_{{slot_number}} = state_group_{{state_group_number}}_state_{{slot_number}} + {{input_offset}}
+          state_group_{{state_group_number}}_state_{{slot_number}} = state_group_{{state_group_number}}_state_{{slot_number}}
         {% else %}
-          state_group_{{state_group_number}}_state_{{slot_number}} = state_group_{{state_group_number}}_state_{{slot_number}} + {{input_offset}},
+          state_group_{{state_group_number}}_state_{{slot_number}} = state_group_{{state_group_number}}_state_{{slot_number}},
         {% endif %}
       {% endfor %}
     {% endfor %});

--- a/chipc/templates/router_data_path_sketch.j2
+++ b/chipc/templates/router_data_path_sketch.j2
@@ -1,4 +1,4 @@
-{% if mode.is_CODEGEN() or mode.is_SOL_VERIFY() or mode.is_CEXGEN() %}
+{% if mode.is_CODEGEN() or mode.is_SOL_VERIFY() or mode.is_VERIFY() %}
   |StateAndPacket| pipeline (|StateAndPacket| state_and_packet) {
   // Any additional constraints to speed up synthesis through parallel execution.
   {{additional_constraints}}
@@ -155,7 +155,7 @@
   return state_and_packet;
 }
 
-{% if mode.is_CODEGEN() or mode.is_CEXGEN() or  mode.is_SOL_VERIFY() %}
+{% if mode.is_CODEGEN() or mode.is_VERIFY() or  mode.is_SOL_VERIFY() %}
   harness void main(
     {{range(num_fields_in_prog)|map('add_prefix_suffix', "int pkt_", "")|join(',')}}
     {% for state_group_number in range(num_state_groups) %}

--- a/example_specs/times_two.sk
+++ b/example_specs/times_two.sk
@@ -1,0 +1,8 @@
+| StateAndPacket | program(| StateAndPacket | state_and_packet) {
+  if (state_and_packet.pkt_0 * 2 == state_and_packet.pkt_1) {
+    state_and_packet.state_group_0_state_0 = 1;
+  } else {
+    state_and_packet.state_group_0_state_0 = 0;
+  }
+  return state_and_packet;
+}

--- a/tests/test_iterative_solver.py
+++ b/tests/test_iterative_solver.py
@@ -124,6 +124,17 @@ class IterativeSolverTest(unittest.TestCase):
                 '2', '2', '10']),
         )
 
+    def test_times_two(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'times_two.sk'),
+                path.join(STATEFUL_ALU_DIR, 'if_else_raw.stateful_alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.j2'),
+                '3', '3', '10']),
+        )
+
     def test_set_default_values(self):
         num_fields_in_prog = 2
         state_group_info = {


### PR DESCRIPTION
Instead of trying to generate counterexamples for different input ranges, find one from n (currently 10) bit input range. If there is no such one, we know that the hole value assignments work for n bit input ranges. Otherwise, update the sketch with assertions to check for that and try again. 

Also removed input_offset that was causing issue #128, and added a new test times_two.sk which was used to find a fix for #128. 

SOL_VERIFY enum is no longer used, but it is left as is. We can clean that up with another PR. 