### PR TITLE
Deterministic compilation results. 

### DIFF
--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -3,6 +3,7 @@ import itertools
 import math
 import os
 import signal
+from collections import OrderedDict
 from os import path
 from pathlib import Path
 
@@ -136,7 +137,7 @@ class Compiler:
             holes_to_values = get_hole_value_assignments(
                 self.sketch_generator.hole_names_, output)
         else:
-            holes_to_values = dict()
+            holes_to_values = OrderedDict()
         return (ret_code, output, holes_to_values)
 
     def serial_codegen(self, iter_cnt=1, additional_constraints=[],

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -147,6 +147,9 @@ def main(argv):
         '_' + str(args.num_pipeline_stages) + \
         '_' + str(args.num_alus_per_stage)
 
+    # Use OrderedSet here for deterministic compilation results. We can also
+    # use built-in dict() for Python versions 3.6 and later, as it's inherently
+    # ordered.
     constant_set = OrderedSet(args.constant_set.split(','))
 
     compiler = Compiler(args.program_file, args.stateful_alu_file,

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -3,6 +3,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from ordered_set import OrderedSet
+
 from chipc.compiler import Compiler
 from chipc.utils import compilation_failure
 from chipc.utils import compilation_success
@@ -145,7 +147,7 @@ def main(argv):
         '_' + str(args.num_pipeline_stages) + \
         '_' + str(args.num_alus_per_stage)
 
-    constant_set = set(args.constant_set.split(','))
+    constant_set = OrderedSet(args.constant_set.split(','))
 
     compiler = Compiler(args.program_file, args.stateful_alu_file,
                         args.stateless_alu_file,

--- a/chipc/sketch_generator.py
+++ b/chipc/sketch_generator.py
@@ -1,4 +1,5 @@
 import math
+from collections import OrderedDict
 from pathlib import Path
 
 from antlr4 import CommonTokenStream
@@ -251,7 +252,8 @@ class SketchGenerator:
         return ret
 
     def generate_sketch(self, program_file, mode, additional_constraints=[],
-                        hole_assignments=dict(), additional_testcases=''):
+                        hole_assignments=OrderedDict(),
+                        additional_testcases=''):
         self.reset_holes_and_asserts()
         assert(mode in [Mode.CODEGEN, Mode.VERIFY])
         if (self.synthesized_allocation_):

--- a/chipc/sketch_utils.py
+++ b/chipc/sketch_utils.py
@@ -68,7 +68,7 @@ def generate_ir(sketch_file_name):
         '--debug-output-dag', dag_file_name,
         # We only want the dag and sketch output is irrelevant here. So quickly
         # return from it using --slv-timeout.
-        '--slv-seed', '1'
+        '--slv-seed', '1',
         '--slv-timeout', str(SLV_TIMEOUT_MINS)
     ],
         # Pipe stdout and stderr to /dev/null as we don't need them.

--- a/chipc/sketch_utils.py
+++ b/chipc/sketch_utils.py
@@ -68,6 +68,7 @@ def generate_ir(sketch_file_name):
         '--debug-output-dag', dag_file_name,
         # We only want the dag and sketch output is irrelevant here. So quickly
         # return from it using --slv-timeout.
+        '--slv-seed', '1'
         '--slv-timeout', str(SLV_TIMEOUT_MINS)
     ],
         # Pipe stdout and stderr to /dev/null as we don't need them.

--- a/chipc/stateful_alu_sketch_generator.py
+++ b/chipc/stateful_alu_sketch_generator.py
@@ -61,7 +61,7 @@ class StatefulALUSketchGenerator(aluVisitor):
                               'return old_state_group;\n}else{\n' +\
                               'return state_group;\n}\n\n}'
         argument_string = ','.join(
-            ['int ' + hole for hole in self.alu_args])
+            ['int ' + hole for hole in sorted(self.alu_args)])
         self.main_function = self.main_function % argument_string
 
     @overrides

--- a/chipc/stateful_alu_sketch_generator.py
+++ b/chipc/stateful_alu_sketch_generator.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from textwrap import dedent
 
 from overrides import overrides
@@ -21,8 +22,8 @@ class StatefulALUSketchGenerator(aluVisitor):
         self.opt_count = 0
         self.constant_count = 0
         self.helper_function_strings = '\n\n\n'
-        self.alu_args = dict()
-        self.global_holes = dict()
+        self.alu_args = OrderedDict()
+        self.global_holes = OrderedDict()
         self.main_function = ''
 
     # Copied From Taegyun's code
@@ -60,7 +61,7 @@ class StatefulALUSketchGenerator(aluVisitor):
                               'return old_state_group;\n}else{\n' +\
                               'return state_group;\n}\n\n}'
         argument_string = ','.join(
-            ['int ' + hole for hole in sorted(self.alu_args)])
+            ['int ' + hole for hole in self.alu_args])
         self.main_function = self.main_function % argument_string
 
     @overrides

--- a/chipc/stateless_alu_sketch_generator.py
+++ b/chipc/stateless_alu_sketch_generator.py
@@ -1,5 +1,6 @@
 import math
 import re
+from collections import OrderedDict
 from textwrap import dedent
 
 from overrides import overrides
@@ -27,8 +28,8 @@ class StatelessAluSketchGenerator (aluVisitor):
         self.optCount = 0
         self.constCount = 0
         self.helperFunctionStrings = '\n\n\n'
-        self.globalholes = dict()
-        self.stateless_alu_args = dict()
+        self.globalholes = OrderedDict()
+        self.stateless_alu_args = OrderedDict()
         self.mainFunction = ''
         self.num_packet_fields = 0
         self.packet_fields = []
@@ -132,7 +133,7 @@ class StatelessAluSketchGenerator (aluVisitor):
         if len(self.stateless_alu_args) > 2:
 
             argument_string = ',' + ','.join(
-                ['int ' + hole for hole in sorted(self.stateless_alu_args)])
+                ['int ' + hole for hole in self.stateless_alu_args])
 
         self.mainFunction = self.mainFunction % argument_string
 

--- a/chipc/stateless_alu_sketch_generator.py
+++ b/chipc/stateless_alu_sketch_generator.py
@@ -133,7 +133,7 @@ class StatelessAluSketchGenerator (aluVisitor):
         if len(self.stateless_alu_args) > 2:
 
             argument_string = ',' + ','.join(
-                ['int ' + hole for hole in self.stateless_alu_args])
+                ['int ' + hole for hole in sorted(self.stateless_alu_args)])
 
         self.mainFunction = self.mainFunction % argument_string
 

--- a/chipc/utils.py
+++ b/chipc/utils.py
@@ -1,7 +1,9 @@
 """Utilities for Chipmunk"""
-from collections import defaultdict
+from collections import OrderedDict
 from pathlib import Path
 from re import findall
+
+from ordered_set import OrderedSet
 
 
 def get_state_group_info(program):
@@ -9,10 +11,12 @@ def get_state_group_info(program):
     indices.
     For state_group_0_state_1, the dict will have an entry {0: set(1)}"""
 
-    state_group_info = defaultdict(set)
+    state_group_info = OrderedDict()
     for i, j in findall(
             r'state_and_packet.state_group_(\d+)_state_(\d+)', program):
-        state_group_info[i].add(j)
+        indices = state_group_info.get(i, OrderedSet())
+        indices.add(j)
+        state_group_info[i] = indices
 
     return state_group_info
 

--- a/chipc/z3_utils.py
+++ b/chipc/z3_utils.py
@@ -65,6 +65,9 @@ def generate_counterexamples(formula):
     z3_slv.set(proof=True, unsat_core=True, random_seed=1)
     z3_slv.add(new_formula)
 
+    # Use OrderedDict here for deterministic compilation results. We can also
+    # use built-in dict() for Python versions 3.6 and later, as it's inherently
+    # ordered.
     pkt_fields = collections.OrderedDict()
     state_vars = collections.OrderedDict()
 

--- a/chipc/z3_utils.py
+++ b/chipc/z3_utils.py
@@ -119,7 +119,7 @@ def get_z3_formula(sketch_ir: str, input_bits: int) -> z3.QuantifierRef:
     formula corresponding to that IR with the specified input bits for source
     variables."""
 
-    z3_vars = dict()
+    z3_vars = collections.OrderedDict()
     z3_asserts = []
     z3_srcs = []
     for line in sketch_ir.splitlines():

--- a/chipc/z3_utils.py
+++ b/chipc/z3_utils.py
@@ -59,7 +59,9 @@ def generate_counterexamples(formula):
     new_formula = negated_body(formula)
 
     z3_slv = z3.Solver()
-    z3_slv.set(proof=True, unsat_core=True)
+    # To get counterexamples we need to set proof and unsat_core. Random seed
+    # is set for determinism.
+    z3_slv.set(proof=True, unsat_core=True, random_seed=1)
     z3_slv.add(new_formula)
 
     pkt_fields = {}

--- a/chipc/z3_utils.py
+++ b/chipc/z3_utils.py
@@ -1,3 +1,4 @@
+import collections
 import re
 
 import z3
@@ -64,8 +65,8 @@ def generate_counterexamples(formula):
     z3_slv.set(proof=True, unsat_core=True, random_seed=1)
     z3_slv.add(new_formula)
 
-    pkt_fields = {}
-    state_vars = {}
+    pkt_fields = collections.OrderedDict()
+    state_vars = collections.OrderedDict()
 
     result = z3_slv.check()
     if result != z3.sat:

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ setup(
     # This will let setuptools to copy ver what"s listed in MANIFEST.in
     include_package_data=True,
     install_requires=[
-        'antlr4-python3-runtime>=4.7.2', 'Jinja2>=2.10', 'overrides>=1.9',
-        'psutil>=5.6.1', 'z3-solver>=4.8.0.0'
+        'antlr4-python3-runtime>=4.7.2', 'Jinja2>=2.10', 'ordered_set>=3.1.1',
+        'overrides>=1.9', 'psutil>=5.6.1', 'z3-solver>=4.8.0.0'
     ],
     cmdclass={
         'build_py': BuildPyWrapper,


### PR DESCRIPTION
Addresses #178. 

1. Set random seed for z3 Solver
2. Use collections.OrderedDict instead of built-in dict().
3. Use ordered_set.OrderedSet instead of built-in set(). 

Note that we still need to think carefully not to break this whenever we modify the code that updates sketch. 

As commented, we could have avoided this issue if we have used Python 3.6 or later. 