### PR TITLE
Update alu filename.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include chipc/stateful_alu.g4
+include chipc/alu.g4
 include chipc/templates/*.j2


### PR DESCRIPTION
This is necessary to pass alu.g4 correctly when installing. #157 missed this.