### PR TITLE
Test only whether counterexamples are generated not their actual values. 

### DIFF
--- a/tests/test_z3_utils.py
+++ b/tests/test_z3_utils.py
@@ -50,9 +50,10 @@ class GenerateCounterexamplesTest(unittest.TestCase):
     def test_successs_with_mock(self):
         x = z3.Int('pkt_0_0_0_0')
         simple_formula = z3.ForAll([x], z3.And(x > 3, x < 2))
-        pkt_fields, _ = z3_utils.generate_counterexamples(
+        pkt_fields, state_vars = z3_utils.generate_counterexamples(
             simple_formula)
         self.assertTrue('pkt_0' in pkt_fields)
+        self.assertDictEqual(state_vars, {})
 
     def test_unsat_formula(self):
         x = z3.Int('x')
@@ -64,8 +65,9 @@ class GenerateCounterexamplesTest(unittest.TestCase):
     def test_state_group_with_alphabets(self):
         x = z3.Int('state_group_1_state_0_b_b_0')
         simple_formula = z3.ForAll([x], z3.And(x > 3, x < 2))
-        _, state_vars = z3_utils.generate_counterexamples(
+        pkt_fields, state_vars = z3_utils.generate_counterexamples(
             simple_formula)
+        self.assertDictEqual(pkt_fields, {})
         self.assertTrue('state_group_1_state_0' in state_vars)
 
 

--- a/tests/test_z3_utils.py
+++ b/tests/test_z3_utils.py
@@ -47,12 +47,27 @@ class NegatedBodyTest(unittest.TestCase):
 
 
 class GenerateCounterexamplesTest(unittest.TestCase):
+    def test_successs_with_mock(self):
+        x = z3.Int('pkt_0_0_0_0')
+        simple_formula = z3.ForAll([x], z3.And(x > 3, x < 2))
+        pkt_fields, _ = z3_utils.generate_counterexamples(
+            simple_formula)
+        self.assertTrue('pkt_0' in pkt_fields)
+
     def test_unsat_formula(self):
         x = z3.Int('x')
         equality = z3.ForAll([x], x == x)
         pkt_fields, state_vars = z3_utils.generate_counterexamples(equality)
         self.assertDictEqual(pkt_fields, {})
         self.assertDictEqual(state_vars, {})
+
+    def test_state_group_with_alphabets(self):
+        x = z3.Int('state_group_1_state_0_b_b_0')
+        simple_formula = z3.ForAll([x], z3.And(x > 3, x < 2))
+        _, state_vars = z3_utils.generate_counterexamples(
+            simple_formula)
+        self.assertTrue('state_group_1_state_0' in state_vars)
+
 
 class GetZ3FormulaTest(unittest.TestCase):
     def test_conversion(self):


### PR DESCRIPTION
#195 caught this. Actual counterexample values might be different per machine/run. Fixes #196.