### PR TITLE
Add slicing algo

### DIFF
--- a/chipc/compiler.py
+++ b/chipc/compiler.py
@@ -42,7 +42,8 @@ class Compiler:
                  stateless_alu_filename, num_pipeline_stages,
                  num_alus_per_stage, sketch_name, parallel_sketch,
                  constant_set, synthesized_allocation=False,
-                 pkt_fields_to_check=[]):
+                 pkt_fields_to_check=[],
+                 state_groups_to_check=[]):
         self.spec_filename = spec_filename
         self.stateful_alu_filename = stateful_alu_filename
         self.stateless_alu_filename = stateless_alu_filename
@@ -74,8 +75,13 @@ class Compiler:
             trim_blocks=True,
             lstrip_blocks=True)
 
-        if not pkt_fields_to_check:
+        if not pkt_fields_to_check and not state_groups_to_check:
             pkt_fields_to_check = list(range(self.num_fields_in_prog))
+            state_groups_to_check = list(range(self.num_state_groups))
+        elif not pkt_fields_to_check and state_groups_to_check:
+            pkt_fields_to_check = []
+        elif pkt_fields_to_check and not state_groups_to_check:
+            state_groups_to_check = []
 
         # Create an object for sketch generation
         self.sketch_code_generator = SketchCodeGenerator(
@@ -86,6 +92,7 @@ class Compiler:
             num_state_groups=self.num_state_groups,
             num_fields_in_prog=self.num_fields_in_prog,
             pkt_fields_to_check=pkt_fields_to_check,
+            state_groups_to_check=state_groups_to_check,
             jinja2_env=self.jinja2_env,
             stateful_alu_filename=stateful_alu_filename,
             stateless_alu_filename=stateless_alu_filename,

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -80,6 +80,20 @@ def generate_counterexample_asserts(pkt_fields, state_vars, num_fields_in_prog,
             count) + ')' + ' == ' + 'program(' + 'x_' + str(
                 count) + '));\n'
     elif output_packet_fields is not None and state_group_to_check is None:
+        # If our spec only cares about specific packet fields,
+        # the counterexample generated should also care about
+        # the same packet fields
+        # For example, we only care about pkt_0 then the counterexample
+        # assert should be assert(pipeline(x_1).pkt_0 == program(x_1).pkt_0)
+
+        # Same case for stateful_groups except we should care about the size
+        # of state group
+        # For example, we only care about the state_group_0 with the size
+        # of this group to be 2, then the counterexample assert should be
+        # assert(pipeline(x_1).state_group_0_state_0 ==
+        # program(x_1).state_group_0_state_0)
+        # assert(pipeline(x_1).state_group_0_state_1 ==
+        # program(x_1).state_group_0_state_1)
         for i in range(len(output_packet_fields)):
             counterexample_asserts += 'assert (pipeline(' + 'x_' + str(
                 count) + ').pkt_' + str(output_packet_fields[i]) + \

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -110,6 +110,11 @@ def main(argv):
         nargs='+',
         help='Packet fields to check correctness')
     parser.add_argument(
+        '--state-groups',
+        type=int,
+        nargs='+',
+        help='State groups to check correctness')
+    parser.add_argument(
         '-p',
         '--parallel',
         action='store_true',
@@ -159,7 +164,7 @@ def main(argv):
                         sketch_name, args.parallel_sketch,
                         constant_set,
                         args.synthesized_allocation,
-                        args.pkt_fields)
+                        args.pkt_fields, args.state_groups)
     # Repeatedly run synthesis at 2 bits and verification using all valid ints
     # until either verification succeeds or synthesis fails at 2 bits. Note
     # that the verification with all ints, might not work because sketch only

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -169,7 +169,8 @@ def main(argv):
         '--input-packet',
         type=int,
         nargs='+',
-        help='Show the actual packet fields used as the input of spec.')
+        help='Specify those packet fields that will \
+              influence the slicing output')
     parser.add_argument(
         '-p',
         '--parallel',

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -211,7 +211,19 @@ def main(argv):
         '_' + str(args.num_alus_per_stage)
 
     # Get how many members in each state group
-    group_size = len(list(state_group_info.items())[0][1])
+    # state_group_info is OrderedDict which stores the num of state group and
+    # the how many stateful vars in each state group
+    # state_group_info[item] specifies the
+    # num of stateful vars in each state group
+    # In our example, each state group has the same size, so we only pick up
+    # one of them to get the group size
+    # For example,
+    # if state_group_info = OrderedDict([('0', OrderedSet(['0', '1']))])
+    # state_group_info[item] = OrderedSet(['0', '1'])
+    # group_size = 2
+    for item in state_group_info:
+        group_size = len(state_group_info[item])
+        break
 
     # Use OrderedSet here for deterministic compilation results. We can also
     # use built-in dict() for Python versions 3.6 and later, as it's inherently

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -169,8 +169,14 @@ def main(argv):
         '--input-packet',
         type=int,
         nargs='+',
-        help='Specify those packet fields that will \
-              influence the slicing output')
+        help='This is intended to provide user with choice\
+                to pick up the packet fields that will \
+                influence the packet fields/states we\
+                want to check correctness for to feed into chipmunk.\
+                For example, in example_specs/blue_decrease.sk, \
+                packet field pkt_1 only depends on pkt_0, \
+                so we can specify --input-packet=0 when we \
+                set - -pkt-fields=1.')
     parser.add_argument(
         '-p',
         '--parallel',

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -115,6 +115,11 @@ def main(argv):
         nargs='+',
         help='State groups to check correctness')
     parser.add_argument(
+        '--input-packet',
+        type=int,
+        nargs='+',
+        help='Show the actual packet fields used as the input of spec.')
+    parser.add_argument(
         '-p',
         '--parallel',
         action='store_true',
@@ -164,7 +169,8 @@ def main(argv):
                         sketch_name, args.parallel_sketch,
                         constant_set,
                         args.synthesized_allocation,
-                        args.pkt_fields, args.state_groups)
+                        args.pkt_fields, args.state_groups,
+                        args.input_packet)
     # Repeatedly run synthesis at 2 bits and verification using all valid ints
     # until either verification succeeds or synthesis fails at 2 bits. Note
     # that the verification with all ints, might not work because sketch only

--- a/chipc/iterative_solver.py
+++ b/chipc/iterative_solver.py
@@ -56,7 +56,7 @@ def set_default_values(pkt_fields, state_vars, num_fields_in_prog,
 
 def generate_counterexample_asserts(pkt_fields, state_vars, num_fields_in_prog,
                                     state_group_info, count,
-                                    pkt_fields_to_check,
+                                    output_packet_fields,
                                     state_group_to_check, group_size):
     counterexample_defs = ''
     counterexample_asserts = ''
@@ -75,23 +75,23 @@ def generate_counterexample_asserts(pkt_fields, state_vars, num_fields_in_prog,
         else:
             counterexample_defs += ');\n'
 
-    if pkt_fields_to_check is None and state_group_to_check is None:
+    if output_packet_fields is None and state_group_to_check is None:
         counterexample_asserts += 'assert (pipeline(' + 'x_' + str(
             count) + ')' + ' == ' + 'program(' + 'x_' + str(
                 count) + '));\n'
-    elif pkt_fields_to_check is not None and state_group_to_check is None:
-        for i in range(len(pkt_fields_to_check)):
+    elif output_packet_fields is not None and state_group_to_check is None:
+        for i in range(len(output_packet_fields)):
             counterexample_asserts += 'assert (pipeline(' + 'x_' + str(
-                count) + ').pkt_' + str(pkt_fields_to_check[i]) + \
+                count) + ').pkt_' + str(output_packet_fields[i]) + \
                 ' == ' + 'program(' + 'x_' + str(
-                count) + ').pkt_' + str(pkt_fields_to_check[i]) + ');\n'
-    elif pkt_fields_to_check is not None and state_group_to_check is not None:
+                count) + ').pkt_' + str(output_packet_fields[i]) + ');\n'
+    elif output_packet_fields is not None and state_group_to_check is not None:
         # counterexample for packet fields
-        for i in range(len(pkt_fields_to_check)):
+        for i in range(len(output_packet_fields)):
             counterexample_asserts += 'assert (pipeline(' + 'x_' + str(
-                count) + ').pkt_' + str(pkt_fields_to_check[i]) + \
+                count) + ').pkt_' + str(output_packet_fields[i]) + \
                 ' == ' + 'program(' + 'x_' + str(
-                count) + ').pkt_' + str(pkt_fields_to_check[i]) + ');\n'
+                count) + ').pkt_' + str(output_packet_fields[i]) + ');\n'
         # counterexample for stateful groups
         for i in range(len(state_group_to_check)):
             for j in range(group_size):
@@ -102,7 +102,8 @@ def generate_counterexample_asserts(pkt_fields, state_vars, num_fields_in_prog,
                     count) + ').state_group_' + \
                     str(state_group_to_check[i]) + '_state_' + str(j) + ');\n'
     else:
-        assert pkt_fields_to_check is None and state_group_to_check is not None
+        assert output_packet_fields is None
+        assert state_group_to_check is not None
         for i in range(len(state_group_to_check)):
             for j in range(group_size):
                 counterexample_asserts += 'assert (pipeline(' + 'x_' + str(

--- a/chipc/sketch_code_generator.py
+++ b/chipc/sketch_code_generator.py
@@ -26,7 +26,8 @@ def add_prefix_suffix(text, prefix_string, suffix_string):
 class SketchCodeGenerator:
     def __init__(self, sketch_name, num_phv_containers, num_state_groups,
                  num_alus_per_stage, num_pipeline_stages, num_fields_in_prog,
-                 pkt_fields_to_check, jinja2_env, stateful_alu_filename,
+                 pkt_fields_to_check, state_groups_to_check,
+                 jinja2_env, stateful_alu_filename,
                  stateless_alu_filename, constant_set,
                  synthesized_allocation):
         self.sketch_name_ = sketch_name
@@ -43,6 +44,7 @@ class SketchCodeGenerator:
         self.num_alus_per_stage_ = num_alus_per_stage
         self.num_fields_in_prog_ = num_fields_in_prog
         self.pkt_fields_to_check_ = pkt_fields_to_check
+        self.state_groups_to_check_ = state_groups_to_check
         self.jinja2_env_ = jinja2_env
         self.jinja2_env_.filters['add_prefix_suffix'] = add_prefix_suffix
         self.stateful_alu_filename_ = stateful_alu_filename
@@ -355,6 +357,7 @@ class SketchCodeGenerator:
             alu_definitions=alu_definitions,
             num_fields_in_prog=self.num_fields_in_prog_,
             pkt_fields_to_check=self.pkt_fields_to_check_,
+            state_groups_to_check=self.state_groups_to_check_,
             num_state_groups=self.num_state_groups_,
             spec_as_sketch=Path(spec_filename).read_text(),
             all_assertions=self.asserts_,

--- a/chipc/sketch_code_generator.py
+++ b/chipc/sketch_code_generator.py
@@ -29,7 +29,7 @@ class SketchCodeGenerator:
                  pkt_fields_to_check, state_groups_to_check,
                  jinja2_env, stateful_alu_filename,
                  stateless_alu_filename, constant_set,
-                 synthesized_allocation):
+                 synthesized_allocation, input_packet):
         self.sketch_name_ = sketch_name
         self.total_hole_bits_ = 0
         self.hole_names_ = []
@@ -62,6 +62,7 @@ class SketchCodeGenerator:
         self.num_operands_to_stateful_alu_ = 0
         self.num_state_slots_ = 0
         self.synthesized_allocation_ = synthesized_allocation
+        self.input_packet_ = input_packet
 
     def reset_holes_and_asserts(self):
         self.total_hole_bits_ = 0
@@ -371,4 +372,5 @@ class SketchCodeGenerator:
             hole_assignments=self.constant_arr_def_ + '\n'.join(
                 ['int ' + str(hole) + ' = ' + str(value) + ';'
                     for hole, value in hole_assignments.items()]),
-            additional_testcases=additional_testcases)
+            additional_testcases=additional_testcases,
+            input_packet=self.input_packet_)

--- a/chipc/sketch_code_generator.py
+++ b/chipc/sketch_code_generator.py
@@ -26,10 +26,10 @@ def add_prefix_suffix(text, prefix_string, suffix_string):
 class SketchCodeGenerator:
     def __init__(self, sketch_name, num_phv_containers, num_state_groups,
                  num_alus_per_stage, num_pipeline_stages, num_fields_in_prog,
-                 pkt_fields_to_check, state_groups_to_check,
+                 output_packet_fields, output_state_groups,
                  jinja2_env, stateful_alu_filename,
                  stateless_alu_filename, constant_set,
-                 synthesized_allocation, input_packet):
+                 synthesized_allocation, input_packet_fields):
         self.sketch_name_ = sketch_name
         self.total_hole_bits_ = 0
         self.hole_names_ = []
@@ -43,8 +43,8 @@ class SketchCodeGenerator:
         self.num_state_groups_ = num_state_groups
         self.num_alus_per_stage_ = num_alus_per_stage
         self.num_fields_in_prog_ = num_fields_in_prog
-        self.pkt_fields_to_check_ = pkt_fields_to_check
-        self.state_groups_to_check_ = state_groups_to_check
+        self.output_packet_fields_ = output_packet_fields
+        self.output_state_groups_ = output_state_groups
         self.jinja2_env_ = jinja2_env
         self.jinja2_env_.filters['add_prefix_suffix'] = add_prefix_suffix
         self.stateful_alu_filename_ = stateful_alu_filename
@@ -62,7 +62,7 @@ class SketchCodeGenerator:
         self.num_operands_to_stateful_alu_ = 0
         self.num_state_slots_ = 0
         self.synthesized_allocation_ = synthesized_allocation
-        self.input_packet_ = input_packet
+        self.input_packet_fields_ = input_packet_fields
 
     def reset_holes_and_asserts(self):
         self.total_hole_bits_ = 0
@@ -357,8 +357,8 @@ class SketchCodeGenerator:
             output_mux_definitions=output_mux_definitions,
             alu_definitions=alu_definitions,
             num_fields_in_prog=self.num_fields_in_prog_,
-            pkt_fields_to_check=self.pkt_fields_to_check_,
-            state_groups_to_check=self.state_groups_to_check_,
+            output_packet_fields=self.output_packet_fields_,
+            output_state_groups=self.output_state_groups_,
             num_state_groups=self.num_state_groups_,
             spec_as_sketch=Path(spec_filename).read_text(),
             all_assertions=self.asserts_,
@@ -373,4 +373,4 @@ class SketchCodeGenerator:
                 ['int ' + str(hole) + ' = ' + str(value) + ';'
                     for hole, value in hole_assignments.items()]),
             additional_testcases=additional_testcases,
-            input_packet=self.input_packet_)
+            input_packet_fields=self.input_packet_fields_)

--- a/chipc/templates/router_data_path_sketch.j2
+++ b/chipc/templates/router_data_path_sketch.j2
@@ -41,15 +41,17 @@
     // Inputs
     {% if stage_number == 0 %}
       // Read each PHV container from corresponding packet field.
-      {% for field_number in range(num_fields_in_prog) %}
+      {% for field_number in input_packet %}
         {% if synthesized_allocation %}
+        // TODO: deal with the case where not all packets are fed as input
         {% for container_number in range(num_phv_containers) %}
            if (phv_config_{{field_number}}_{{container_number}} == 1){
               input_0_{{container_number}} = state_and_packet.pkt_{{field_number}};
            }
         {% endfor %}
         {% else %}
-        input_0_{{field_number}} = state_and_packet.pkt_{{field_number}};
+        // loop.index starts from 1 that's why we need to -1
+        input_0_{{loop.index - 1}} = state_and_packet.pkt_{{field_number}};
         {% endif %}
       {% endfor %}
 
@@ -204,7 +206,7 @@
     {% endfor %}
     {% endfor %}
 
-  {% for field_number in range(num_fields_in_prog) %}
+  {% for field_number in pkt_fields_to_check %}
     // Write pkt_{{field_number}}
     {% if synthesized_allocation %}
     {% for container_number in range(num_phv_containers) %}
@@ -213,7 +215,7 @@
         }
     {% endfor %}
     {% else%}
-    state_and_packet.pkt_{{field_number}} = output_{{num_pipeline_stages - 1}}_{{field_number}};
+    state_and_packet.pkt_{{field_number}} = output_{{num_pipeline_stages - 1}}_{{loop.index - 1}};
     {% endif %}
   {% endfor %}
 

--- a/chipc/templates/router_data_path_sketch.j2
+++ b/chipc/templates/router_data_path_sketch.j2
@@ -41,7 +41,7 @@
     // Inputs
     {% if stage_number == 0 %}
       // Read each PHV container from corresponding packet field.
-      {% for field_number in input_packet %}
+      {% for field_number in input_packet_fields %}
         {% if synthesized_allocation %}
         // TODO: deal with the case where not all packets are fed as input
         {% for container_number in range(num_phv_containers) %}
@@ -206,7 +206,7 @@
     {% endfor %}
     {% endfor %}
 
-  {% for field_number in pkt_fields_to_check %}
+  {% for field_number in output_packet_fields %}
     // Write pkt_{{field_number}}
     {% if synthesized_allocation %}
     {% for container_number in range(num_phv_containers) %}
@@ -248,14 +248,14 @@
   |StateAndPacket| pipeline_result = pipeline(x);
   |StateAndPacket| program_result = program(x);
 
-  {% for state_group_number in state_groups_to_check %}
+  {% for state_group_number in output_state_groups %}
     {% for slot_number in range(num_state_slots) %}
       assert(pipeline_result.state_group_{{state_group_number}}_state_{{slot_number}}
       == program_result.state_group_{{state_group_number}}_state_{{slot_number}});
     {% endfor %}
   {% endfor %}
 
-  {% for field_number in pkt_fields_to_check %}
+  {% for field_number in output_packet_fields %}
     assert(pipeline_result.pkt_{{field_number}} == program_result.pkt_{{field_number}});
   {% endfor %}
 

--- a/chipc/templates/router_data_path_sketch.j2
+++ b/chipc/templates/router_data_path_sketch.j2
@@ -246,7 +246,7 @@
   |StateAndPacket| pipeline_result = pipeline(x);
   |StateAndPacket| program_result = program(x);
 
-  {% for state_group_number in range(num_state_groups) %}
+  {% for state_group_number in state_groups_to_check %}
     {% for slot_number in range(num_state_slots) %}
       assert(pipeline_result.state_group_{{state_group_number}}_state_{{slot_number}}
       == program_result.state_group_{{state_group_number}}_state_{{slot_number}});

--- a/tests/test_iterative_solver.py
+++ b/tests/test_iterative_solver.py
@@ -83,6 +83,58 @@ class IterativeSolverTest(unittest.TestCase):
                 '4', '2', '0,1,2,3', '10']),
         )
 
+    def test_blue_increase_1_1_pred_raw_cex_mode_pkt0(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_increase.sk'),
+                path.join(STATEFUL_ALU_DIR, 'pred_raw.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '1', '1', '0,1,2,3', '10',
+                '--pkt-fields=0',
+                '--input-packet', '0']),
+        )
+
+    def test_blue_increase_1_1_pred_raw_cex_mode_pkt1(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_increase.sk'),
+                path.join(STATEFUL_ALU_DIR, 'pred_raw.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '4', '2', '0,1,2,3', '10',
+                '--pkt-fields=1',
+                '--input-packet', '0']),
+        )
+
+    def test_blue_increase_3_2_pred_raw_cex_mode_s0(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_increase.sk'),
+                path.join(STATEFUL_ALU_DIR, 'pred_raw.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '3', '2', '0,1,2,3', '10',
+                '--state-groups', '0',
+                '--input-packet', '0', '1']),
+        )
+
+    def test_blue_increase_2_2_pred_raw_cex_mode_s1(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_increase.sk'),
+                path.join(STATEFUL_ALU_DIR, 'pred_raw.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '2', '2', '0,1,2,3', '10',
+                '--state-groups', '1',
+                '--input-packet', '0', '1']),
+        )
+
     @unittest.skip('Takes too long on AppVeyor')
     def test_blue_increase_4_2_pred_raw_cex_mode_synthesized_alloc(self):
         self.assertEqual(
@@ -165,6 +217,58 @@ class IterativeSolverTest(unittest.TestCase):
                 path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
                 '4', '2', '0,1,2,3', '10',
                 '--synthesized-allocation']),
+        )
+
+    def test_blue_decrease_1_1_sub_cex_mode_pkt0(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_decrease.sk'),
+                path.join(STATEFUL_ALU_DIR, 'sub.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '1', '1', '0,1,2,3', '10',
+                '--pkt-fields=0',
+                '--input-packet', '0']),
+        )
+
+    def test_blue_decrease_1_1_sub_cex_mode_pkt1(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_decrease.sk'),
+                path.join(STATEFUL_ALU_DIR, 'sub.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '1', '1', '0,1,2,3', '10',
+                '--pkt-fields=1',
+                '--input-packet', '0']),
+        )
+
+    def test_blue_decrease_2_2_sub_cex_mode_s0(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_decrease.sk'),
+                path.join(STATEFUL_ALU_DIR, 'sub.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '2', '2', '0,1,2,3', '10',
+                '--state-groups=0',
+                '--input-packet', '0', '1']),
+        )
+
+    def test_blue_decrease_2_2_sub_cex_mode_s1(self):
+        self.assertEqual(
+            0,
+            iterative_solver.main([
+                'iterative_solver',
+                path.join(SPEC_DIR, 'blue_decrease.sk'),
+                path.join(STATEFUL_ALU_DIR, 'sub.alu'),
+                path.join(STATELESS_ALU_DIR, 'stateless_alu.alu'),
+                '2', '2', '0,1,2,3', '10',
+                '--state-groups=1',
+                '--input-packet', '0', '1']),
         )
 
     def test_marple_tcp_nmo_3_2_pred_raw_cex_mode(self):


### PR DESCRIPTION
We want to use slicing Algo to speed up synthesis time. 

There are three main parts of slicing, slicing the spec (divide the spec into pieces where each piece is responsible for synthesis one particular packet field or stateful group), slicing the grid size (we try different grid size in parallel because in most cases the slicing problem is simple enough to finish quickly with small grid size) and slicing the input packet field where we create one influence table before synthesis and only feed those packet fields that have influence on our target spec.